### PR TITLE
fix for filter issues found in student-review lessons

### DIFF
--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -69,11 +69,13 @@ class ContentJsonController extends Controller
             $required_fields[] = 'title,%' . $request->get('title') . '%,string,like';
         }
 
+        $contentTypes = $request->get('included_types', []);
+
         $contentData = $this->contentService->getFiltered(
             $request->get('page', 1),
             $request->get('limit', 10),
             $request->get('sort', '-published_on'),
-            $request->get('included_types', []),
+            $contentTypes,
             $request->get('slug_hierarchy', []),
             $request->get('required_parent_ids', []),
             $required_fields,
@@ -88,20 +90,23 @@ class ContentJsonController extends Controller
 
         $filters = $contentData['filter_options'];
 
+        // Add "All" option, but not in all cases
         foreach ($filters as $key => $filterOptions) {
             if (is_array($filterOptions)) {
-                if (($key != 'content_type') && ($key != 'instructor') && ($key != 'focus') && ($key != 'style')) {
+                $filtersToExclude = ['content_type', 'instructor', 'focus', 'style'];
 
-                    // this skips adding "All" option to the topic or difficulty filter on student-review and
-                    // student-focus catalogues because—at least as of July 2022—it will make for poor options
-                    $includedTypes = $request->get('included_types', []);
-                    $isStudentFocusOrReview =
-                        ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
-                    if ($isStudentFocusOrReview && (($key == 'topic') || ($key == 'difficulty'))) {
-                        continue;
-                    }
+                // It is deliberate that values are *arrays* of single strings. The Catalog pages—that this section
+                // accommodates—have an "included_types" value like this—an array of one string.
+                $isContentTypeWithSpecialConditions = in_array($contentTypes, [
+                    ['student-focus'],
+                    ['student-review']
+                ]);
 
-                    // add "All" option to filter options
+                if ($isContentTypeWithSpecialConditions) {
+                    $filtersToExclude = array_merge($filtersToExclude, ['topic', 'difficulty']);
+                }
+
+                if (!in_array($key, $filtersToExclude)) {
                     $filters[$key] = array_diff($filterOptions, ['All']);
                     array_unshift($filters[$key], 'All');
                 }

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -91,6 +91,17 @@ class ContentJsonController extends Controller
         foreach ($filters as $key => $filterOptions) {
             if (is_array($filterOptions)) {
                 if (($key != 'content_type') && ($key != 'instructor') && ($key != 'focus') && ($key != 'style')) {
+
+                    // this skips adding "All" option to the topic filter on student-review and student-focus catalogues
+                    // as it will break the page
+                    $includedTypes = $request->get('included_types', []);
+                    $isStudentFocusOrReview =
+                        ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
+                    if ($isStudentFocusOrReview && ($key == 'topic')) {
+                        continue;
+                    }
+
+                    // add "All" option to filter options
                     $filters[$key] = array_diff($filterOptions, ['All']);
                     array_unshift($filters[$key], 'All');
                 }

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -92,12 +92,12 @@ class ContentJsonController extends Controller
             if (is_array($filterOptions)) {
                 if (($key != 'content_type') && ($key != 'instructor') && ($key != 'focus') && ($key != 'style')) {
 
-                    // this skips adding "All" option to the topic filter on student-review and student-focus catalogues
-                    // as it will break the page
+                    // this skips adding "All" option to the topic or difficulty filter on student-review and
+                    // student-focus catalogues because—at least as of July 2022—it will make for poor options
                     $includedTypes = $request->get('included_types', []);
                     $isStudentFocusOrReview =
                         ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
-                    if ($isStudentFocusOrReview && ($key == 'topic')) {
+                    if ($isStudentFocusOrReview && (($key == 'topic') || ($key == 'difficulty'))) {
                         continue;
                     }
 

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -892,11 +892,17 @@ class ContentService
                 );
             }
 
+            $filterFields = $filter->getFilterFields() ?? [];
+
+            if ($pullFilterFields && !empty($filterFields['difficulty'])) {
+                $filterFields['difficulty'] = $this->difficultyFilterOptionsCleanup($filterFields['difficulty']);
+            }
+
             $resultsDB = new ContentFilterResultsEntity(
                 [
                     'results' => $filter->retrieveFilter(),
                     'total_results' => $pullPagination ? $filter->countFilter() : 0,
-                    'filter_options' => $pullFilterFields ? $filter->getFilterFields() : [],
+                    'filter_options' => $filterFields,
                 ]
             );
 
@@ -905,6 +911,27 @@ class ContentService
         }
 
         return Decorator::decorate($results, 'content');
+    }
+
+    // for remove extraneous options and order logically rather than alphabetically
+    private function difficultyFilterOptionsCleanup($difficultyOptions)
+    {
+        $hasBeginner = in_array('Beginner', $difficultyOptions);
+        $hasIntermediate = in_array('Intermediate', $difficultyOptions);
+        $hasAdvanced = in_array('Advanced', $difficultyOptions);
+        if ($hasBeginner || $hasIntermediate || $hasAdvanced) {
+            $difficultyOptions = [];
+            if ($hasBeginner) {
+                $difficultyOptions[] = 'Beginner';
+            }
+            if ($hasIntermediate) {
+                $difficultyOptions[] = 'Intermediate';
+            }
+            if ($hasAdvanced) {
+                $difficultyOptions[] = 'Advanced';
+            }
+        }
+        return $difficultyOptions;
     }
 
     /**

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -893,8 +893,15 @@ class ContentService
             }
 
             $filterFields = $filter->getFilterFields() ?? [];
+            $isStudentFocusOrReview =
+                ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
 
-            if ($pullFilterFields && !empty($filterFields['difficulty'])) {
+            /*
+             * for now limited to student-focus and student-reviews as those are currently undergoing some curation by
+             * the content team. for other content types we don't know if there might be a significant number of lessons
+             * that have options that fall outside the limited options that this is desgined to return.
+             */
+            if ($pullFilterFields && !empty($filterFields['difficulty']) && $isStudentFocusOrReview) {
                 $filterFields['difficulty'] = $this->difficultyFilterOptionsCleanup($filterFields['difficulty']);
             }
 
@@ -916,9 +923,13 @@ class ContentService
     // for remove extraneous options and order logically rather than alphabetically
     private function difficultyFilterOptionsCleanup($difficultyOptions)
     {
-        $hasBeginner = in_array('Beginner', $difficultyOptions);
-        $hasIntermediate = in_array('Intermediate', $difficultyOptions);
-        $hasAdvanced = in_array('Advanced', $difficultyOptions);
+        foreach ($difficultyOptions as &$option) {
+            $option = is_string($option) ? strtolower((string) $option) : $option;
+        }
+
+        $hasBeginner = in_array('beginner', $difficultyOptions);
+        $hasIntermediate = in_array('intermediate', $difficultyOptions);
+        $hasAdvanced = in_array('advanced', $difficultyOptions);
         if ($hasBeginner || $hasIntermediate || $hasAdvanced) {
             $difficultyOptions = [];
             if ($hasBeginner) {

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -892,7 +892,7 @@ class ContentService
                 );
             }
 
-            $filterFields = $filter->getFilterFields() ?? [];
+            $filterFields = $pullFilterFields ? $filter->getFilterFields() : [];
             $isStudentFocusOrReview =
                 ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
 

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -893,15 +893,15 @@ class ContentService
             }
 
             $filterFields = $pullFilterFields ? $filter->getFilterFields() : [];
-            $isStudentFocusOrReview =
-                ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
 
-            /*
-             * for now limited to student-focus and student-reviews as those are currently undergoing some curation by
-             * the content team. for other content types we don't know if there might be a significant number of lessons
-             * that have options that fall outside the limited options that this is desgined to return.
-             */
-            if ($pullFilterFields && !empty($filterFields['difficulty']) && $isStudentFocusOrReview) {
+            // It is deliberate that values are *arrays* of single strings. The Catalog pages—that this section
+            // accommodates—have an "included_types" value like this—an array of one string.
+            $isContentTypeWithSpecialConditions = in_array($includedTypes, [
+                ['student-focus'],
+                ['student-review']
+            ]);
+            
+            if ($pullFilterFields && !empty($filterFields['difficulty']) && $isContentTypeWithSpecialConditions) {
                 $filterFields['difficulty'] = $this->difficultyFilterOptionsCleanup($filterFields['difficulty']);
             }
 


### PR DESCRIPTION
This commit is a bit ugly, but this constrains the difficulty filter to only the three desired values.

There's two fixes here, one's used on page-load, and the other for async requests to update the filters after the users interacts with them.