### PR TITLE
adapation of fix for filter issues found in student-review lessons

### DIFF
--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -91,6 +91,17 @@ class ContentJsonController extends Controller
         foreach ($filters as $key => $filterOptions) {
             if (is_array($filterOptions)) {
                 if (($key != 'content_type') && ($key != 'instructor') && ($key != 'focus') && ($key != 'style')) {
+
+                    // this skips adding "All" option to the topic or difficulty filter on student-review and
+                    // student-focus catalogues because—at least as of July 2022—it will make for poor options
+                    $includedTypes = $request->get('included_types', []);
+                    $isStudentFocusOrReview =
+                        ($includedTypes == ['student-focus']) || ($includedTypes == ['student-review']);
+                    if ($isStudentFocusOrReview && (($key == 'topic') || ($key == 'difficulty'))) {
+                        continue;
+                    }
+
+                    // add "All" option to filter options
                     $filters[$key] = array_diff($filterOptions, ['All']);
                     array_unshift($filters[$key], 'All');
                 }


### PR DESCRIPTION
Adapted from similar fix applied to 0.5, see pull for that one here: https://github.com/railroadmedia/railcontent/pull/5

There is one thing added to this one that and that is UNTESTED consideration for when elasticsearch is used to get the content. It's pretty simple, but I wasn't able to test it, so I leave it in your hands about whether this should wait for now lest it break something... or if can include it now to get it out of the way.

It's also not a great fix generally, but it gets the job done.