### PR TITLE
Fixes issue found while investigating BR-673

### DIFF
--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -701,13 +701,14 @@ class ContentRepository extends RepositoryBase
         $orderDirection = 'desc',
         $contentId = null
     ) {
-
         if ($contentId) {
             $beforeSubqueryOne = $this
                 ->query()
-                ->selectRaw(DB::raw(
-                    'ROW_NUMBER() OVER (order by railcontent_content.' . $orderColumn . ' desc, railcontent_content.id desc) AS rowNumber'
-                ))
+                ->selectRaw(
+                    DB::raw(
+                        'ROW_NUMBER() OVER (order by railcontent_content.' . $orderColumn . ' desc, railcontent_content.id desc) AS rowNumber'
+                    )
+                )
                 ->selectPrimaryColumns()
                 ->restrictByUserAccess()
                 ->where(ConfigService::$tableContent . '.type', $type)
@@ -731,15 +732,16 @@ class ContentRepository extends RepositoryBase
 
             $afterSubqueryOne = $this
                 ->query()
-                ->selectRaw(DB::raw(
-                    'ROW_NUMBER() OVER (order by railcontent_content.' . $orderColumn . ' asc, railcontent_content.id asc) AS rowNumber'
-                ))
+                ->selectRaw(
+                    DB::raw(
+                        'ROW_NUMBER() OVER (order by railcontent_content.' . $orderColumn . ' asc, railcontent_content.id asc) AS rowNumber'
+                    )
+                )
                 ->selectPrimaryColumns()
                 ->restrictByUserAccess()
                 ->where(ConfigService::$tableContent . '.type', $type)
                 ->where(ConfigService::$tableContent . '.' . $columnName, '>=', $columnValue)
-                ->limit(70)
-            ;
+                ->limit(70);
 
             $afterSubqueryTwo = $this->query()
                 ->selectRaw(DB::raw('rowNumber'))
@@ -749,13 +751,17 @@ class ContentRepository extends RepositoryBase
                 ->value('rowNumber');
 
             // if $afterSubqueryTwo is null, check if we should not set a higher limit for $afterSubqueryOne
-            $afterContents =
-                $this->query()
-                    ->select('*')
-                    ->fromSub($afterSubqueryOne, 'sub')
-                    ->where('rowNumber', '>', $afterSubqueryTwo)
-                    ->limit($siblingPairLimit)
-                    ->getToArray();
+            if ($afterSubqueryTwo) {
+                $afterContents =
+                    $this->query()
+                        ->select('*')
+                        ->fromSub($afterSubqueryOne, 'sub')
+                        ->where('rowNumber', '>', $afterSubqueryTwo)
+                        ->limit($siblingPairLimit)
+                        ->getToArray();
+            } else {
+                $afterContents = [];
+            }
         } else {
             $beforeContents =
                 $this->query()
@@ -2357,9 +2363,11 @@ class ContentRepository extends RepositoryBase
                 ->toArray();
 
             foreach ($filterOptionsArray[$filterOptionName] as $filterOptionIndexToClean => $filterOptionValueToClean) {
-                $filterOptionsArray[$filterOptionName][$filterOptionIndexToClean] = trim(ucwords(
-                    $filterOptionValueToClean
-                ));
+                $filterOptionsArray[$filterOptionName][$filterOptionIndexToClean] = trim(
+                    ucwords(
+                        $filterOptionValueToClean
+                    )
+                );
             }
 
             $filterOptionsArray[$filterOptionName] = array_unique($filterOptionsArray[$filterOptionName]);

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -750,7 +750,6 @@ class ContentRepository extends RepositoryBase
                 ->get()
                 ->value('rowNumber');
 
-            // if $afterSubqueryTwo is null, check if we should not set a higher limit for $afterSubqueryOne
             if ($afterSubqueryTwo) {
                 $afterContents =
                     $this->query()


### PR DESCRIPTION
https://musoraproduct.myjetbrains.com/youtrack/issue/BR-673/New-Musora-permissions-not-working-without-legacy-perms

Created new content similar to https://admin.musora.com/admin#/content/drumeo/386409 with only the musora permissions.
There was an error when $afterSubqueryTwo was null.

@mirceamartsoft It looks like you were working on this.  The comment was confusing for the case where $afterSubqueryTwo is null.  Currently is throwns an exception for this case causing the page to fail.  Do you think this fix is okay?