### PR TITLE
Add new command and tests for creating a new permission

### DIFF
--- a/src/Commands/CreatePermission.php
+++ b/src/Commands/CreatePermission.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Railroad\Railcontent\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Railroad\Railcontent\Services\ContentService;
+use Railroad\Railcontent\Services\ElasticService;
+use Railroad\Railcontent\Services\PermissionService;
+
+class CreatePermission extends Command
+{
+
+    protected const BRANDS = ["drumeo", "guitareo", "pianote", "singeo"];
+
+    protected $signature = 'content:createPermission 
+                            {brand : The brand to use}
+                            {name : The name to use for the permission}';
+
+    protected $description = 'Create a new permission with the given name for the given brand';
+
+    public function handle(PermissionService $permissionService)
+    {
+        $brand = $this->argument('brand');
+
+        if (!in_array($brand, self::BRANDS)) {
+            $this->error("$brand is not a valid brand");
+            return self::FAILURE;
+        }
+
+        $name = $this->argument('name');
+        $this->info("Creating new permission for $brand, named '$name'");
+
+        $permission = $permissionService->create(
+            $name,
+            $brand
+        );
+
+        $this->info("New permission for {$permission["brand"]}, named '{$permission["name"]}' successfully created");
+        return self::SUCCESS;
+    }
+
+}

--- a/src/Providers/RailcontentServiceProvider.php
+++ b/src/Providers/RailcontentServiceProvider.php
@@ -14,6 +14,7 @@ use Railroad\Railcontent\Commands\CleanContentTopicsAndStyles;
 use Railroad\Railcontent\Commands\CleanMetadata;
 use Railroad\Railcontent\Commands\ComputePastStats;
 use Railroad\Railcontent\Commands\ComputeWeeklyStats;
+use Railroad\Railcontent\Commands\CreatePermission;
 use Railroad\Railcontent\Commands\CreateSearchIndexes;
 use Railroad\Railcontent\Commands\CreateVimeoVideoContentRecords;
 use Railroad\Railcontent\Commands\CreateYoutubeVideoContentRecords;
@@ -143,6 +144,7 @@ class RailcontentServiceProvider extends ServiceProvider
             AddDefaultShowNewField::class,
             ComputePastStats::class,
             ComputeWeeklyStats::class,
+            CreatePermission::class,
             CreateSearchIndexes::class,
             CreateVimeoVideoContentRecords::class,
             RepairMissingDurations::class,

--- a/src/Services/PermissionService.php
+++ b/src/Services/PermissionService.php
@@ -104,7 +104,7 @@ class PermissionService
                 'brand' => $brand ?? ConfigService::$brand
             ]
         );
-        CacheHelper::deleteAllCachedSearchResults('permissions_');
+        CacheHelper::deleteAllCachedSearchResults('permissions_' . CacheHelper::getKey());
 
         return $this->get($permissionId);
     }
@@ -131,7 +131,7 @@ class PermissionService
             ['name' => $name, 'brand' => $brand ?? ConfigService::$brand]
         );
 
-        CacheHelper::deleteAllCachedSearchResults('permissions_');
+        CacheHelper::deleteAllCachedSearchResults('permissions_' . CacheHelper::getKey());
 
         return $this->get($id);
     }
@@ -157,7 +157,7 @@ class PermissionService
             $contentIds = $this->contentRepository->getByType($contentType);
             CacheHelper::deleteCacheKeys($contentIds);
         }
-        CacheHelper::deleteAllCachedSearchResults('permissions_');
+        CacheHelper::deleteAllCachedSearchResults('permissions_' . CacheHelper::getKey());
 
         $this->contentPermissionRepository->unlinkPermissionFromAllContent($id);
 

--- a/tests/Functional/Commands/CreatePermissionTest.php
+++ b/tests/Functional/Commands/CreatePermissionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+
+namespace Railroad\Railcontent\Tests\Functional\Commands;
+
+use Cache;
+use Carbon\Carbon;
+use Railroad\Railcontent\Factories\ContentFactory;
+use Railroad\Railcontent\Factories\ContentPermissionsFactory;
+use Railroad\Railcontent\Factories\PermissionsFactory;
+use Railroad\Railcontent\Helpers\CacheHelper;
+use Railroad\Railcontent\Helpers\ContentHelper;
+use Railroad\Railcontent\Services\ConfigService;
+use Railroad\Railcontent\Services\ContentService;
+use Railroad\Railcontent\Services\PermissionService;
+use Railroad\Railcontent\Tests\RailcontentTestCase;
+
+class CreatePermissionTest extends RailcontentTestCase
+{
+    protected PermissionService $permissionService;
+
+    protected PermissionsFactory $permissionFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->permissionFactory = $this->app->make(PermissionsFactory::class);
+        $this->permissionService = $this->app->make(PermissionService::class);
+
+        // things are a little finicky with doing a clear setup before each test, so make sure we clear out any permissions
+        $existingPermissions = $this->permissionService->getAll();
+        foreach ($existingPermissions as $existingPermission) {
+            $this->permissionService->permissionRepository->delete($existingPermission["id"]);
+        }
+    }
+
+    public function test_command_requires_valid_brand()
+    {
+        $this->artisan('content:createPermission foo "A new permission"')
+            ->expectsOutput("foo is not a valid brand")
+            ->assertFailed();
+    }
+
+    public function test_creates_a_new_permission()
+    {
+        $permissions = $this->permissionService->getAll();
+        $this->assertEmpty($permissions);
+
+        $this->artisan('content:createPermission drumeo "A new permission"')
+            ->expectsOutput("Creating new permission for drumeo, named 'A new permission'")
+            ->expectsOutput("New permission for drumeo, named 'A new permission' successfully created")
+            ->assertSuccessful();
+
+        $permissions = $this->permissionService->getAll();
+        $this->assertCount(1, $permissions);
+
+        $permission = $permissions[0];
+        $this->assertSame("drumeo", $permission["brand"]);
+        $this->assertSame("A new permission", $permission["name"]);
+    }
+
+
+    public function test_new_permission_is_available_in_cache()
+    {
+        $newPermissionName = "Some new permission";
+        $newPermissionBrand = "pianote";
+
+        for ($i = 0; $i < 5; $i++){
+            $this->permissionFactory->create($i);
+        }
+
+        // directly check the cache, because the permission service normally handles this for us
+        $hash = 'permissions_' . CacheHelper::getKey();
+        $cacheResults = CacheHelper::getCachedResultsForKey($hash);
+        $this->assertEmpty($cacheResults);
+
+        // use the permission service, so that it will cache the results
+        $serviceResults = $this->permissionService->getAll();
+        $this->assertCount(5, $serviceResults);
+
+        $this->assertTrue(collect($serviceResults)->contains("name", "1"));
+        $this->assertFalse(collect($serviceResults)->contains("name", $newPermissionName));
+
+        // retrieve the cache directly to ensure it's working as expected
+        $cacheResults = CacheHelper::getCachedResultsForKey($hash);
+
+        $this->assertTrue(collect($cacheResults)->contains("name", "1"));
+        $this->assertFalse(collect($cacheResults)->contains("name", $newPermissionName));
+
+        // use the command to create a new permission
+        $this->artisan("content:createPermission", ["brand" => $newPermissionBrand, "name" => $newPermissionName]);
+
+        // the permission service clears the cache when creating a new permission
+        $cacheResults = CacheHelper::getCachedResultsForKey($hash);
+        $this->assertEmpty($cacheResults);
+
+        // use the permission service, and ensure it cached all the results
+        $serviceResults = $this->permissionService->getAll();
+        $this->assertCount(6, $serviceResults);
+        $this->assertTrue(collect($serviceResults)->contains("name", "1"));
+        $this->assertTrue(collect($serviceResults)->contains("name", $newPermissionName));
+        // retrieve the cache directly to ensure it's working as expected
+        $cacheResults = CacheHelper::getCachedResultsForKey($hash);
+        $this->assertTrue(collect($cacheResults)->contains("name", "1"));
+        $this->assertTrue(collect($cacheResults)->contains("name", $newPermissionName));
+        $this->assertTrue(collect($cacheResults)->contains("brand", $newPermissionBrand));
+
+        // DEV NOTE: the permission service's getByName function isn't actually used anywhere, so testing with it is redundant
+        // $newPermission = $this->permissionService->getByName($newPermissionName)[0];
+        // $this->assertSame($newPermissionName, $newPermission['name']);
+        // $this->assertSame($newPermissionBrand, $newPermission['brand']);
+    }
+}


### PR DESCRIPTION
I added tests to ensure the command works properly and doesn't cause any issues with caching, which in turn led to some additional changes in this branch:

- Updating the CacheHelper to perform (a slightly altered version of) the same functionality within the functions, when the Cache Store is not an instance of RedisStore
- Updated the PermissionService so that it always uses the `'permissions_' . CacheHelper::getKey()` key, instead of just `'permissions_'` that was used sometimes. When I was testing my command and the caching, I found that it was failing to find the cached value, because it was being stored with a different key.

In order to have the tests run on my local, I had to make a couple adjustments to RailContentTestCase.php:

- comment out lines 135-138
- change line 190 to set the railcontent.use_elastic_search to false (instead of using the defaultConfig's setting)

These allowed me to get around failures due to my local not being set up for ElasticSearch