### PR TITLE
Increase length of content_instructors in search_indexes table

### DIFF
--- a/migrations/2023_11_06_150443_increase_search_indexes_content_instructors_length.php
+++ b/migrations/2023_11_06_150443_increase_search_indexes_content_instructors_length.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class IncreaseSearchIndexesContentInstructorsLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection(config('railcontent.database_connection_name'))->table(
+            config('railcontent.table_prefix') . 'search_indexes',
+            function (Blueprint $table) {
+                $table->string('content_instructors', 128)->change();
+            }
+        );
+    }
+
+
+    /**
+     * Reverse the migrations.
+     *
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection(config('railcontent.database_connection_name'))->table(
+            config('railcontent.table_prefix') . 'search_indexes',
+            function (Blueprint $table) {
+                $table->string('content_instructors', 64)->change();
+            }
+        );
+    }
+}


### PR DESCRIPTION
When running `command:createSearchIndexesForContents` I got this error: 

> String data, right truncated: 1406 Data too long for column 'content_instructors' at row 1 ...

After checking the db, I found that we have 3 entries in the  railcontent_content_instructors table that will exceed the limit of 64 characters, so I've bumped the length up to 128.