### PR TITLE
Filter v2

### DIFF
--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -99,10 +99,10 @@ class ContentJsonController extends Controller
 
         $group_by = false;
         $contentTypes = $request->get('included_types', []);
-        if($request->get('tab', false)){
-            $tabs = $request->get('tab');
-            if(!is_array($request->get('tab'))){
-                $tabs = [$request->get('tab')];
+        if($request->get('tabs', false)){
+            $tabs = $request->get('tabs');
+            if(!is_array($request->get('tabs'))){
+                $tabs = [$request->get('tabs')];
             }
             foreach($tabs as $tab) {
                 $extra = explode(',', $tab);

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -102,11 +102,11 @@ class ContentJsonController extends Controller
             }
         }
 
-        $group_by = false;
+        $group_by = null;
         $contentTypes = $request->get('included_types', []);
 
         [$group_by, $required_fields, $included_fields] =
-            $this->extractFields($request, $group_by, $required_fields, $included_fields);
+            $this->extractFields($request, $required_fields, $included_fields, $group_by);
 
         $contentData = $this->contentService->getFiltered(
             $request->get('page', 1),
@@ -124,7 +124,7 @@ class ContentJsonController extends Controller
             true,
             $request->get('only_subscribed', false),
             $futureScheduledContentOnly,
-            $group_by ?? false,
+            $group_by ?? null,
         );
 
         $filters = $contentData['filter_options'];
@@ -539,13 +539,13 @@ class ContentJsonController extends Controller
     }
 
     /**
- * @param Request $request
- * @param string $group_by
- * @param mixed $required_fields
- * @param mixed $included_fields
- * @return array
- */
-    private function extractFields(Request $request, string $group_by, mixed $required_fields, mixed $included_fields)
+     * @param Request $request
+     * @param mixed $required_fields
+     * @param mixed $included_fields
+     * @param string|null $group_by
+     * @return array
+     */
+    private function extractFields(Request $request, mixed $required_fields, mixed $included_fields,?string $group_by )
     : array {
         $tabs = $request->get('tabs', $request->get('tab', false));
         if ($tabs) {

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -572,7 +572,7 @@ class ContentJsonController extends Controller
             $instructors =
                 $this->contentService->getWhereTypeInAndStatusAndField(
                     ['instructor'],
-                    ['published'],
+                    'published',
                     'name',
                     '%'.$request->get('title').'%',
                     'string',

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -135,7 +135,7 @@ class ContentJsonController extends Controller
             foreach($instructors->pluck('id') ?? [] as $instructor){
                 $included_fields[] = 'instructor,'.$instructor.',integer,=';
             }
-        }else{
+        }elseif($request->has('title')){
             $required_fields[] = 'title,%'.$request->get('title').'%,string,like';
         }
         $contentData = $this->contentService->getFiltered(

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -105,7 +105,7 @@ class ContentJsonController extends Controller
 
         $group_by = null;
         $contentTypes = $request->get('included_types', []);
-        if(count($contentTypes) > 5){
+        if(count($contentTypes) > 5 && $request->has('count_filter_items')){
             $required_fields[] = 'published_on,'.Carbon::now()->subMonth(3)->toDateTimeString().',date,>=';
         }
         [$group_by, $required_fields, $included_fields] =

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -547,10 +547,10 @@ class ContentJsonController extends Controller
  */
     private function extractFields(Request $request, string $group_by, mixed $required_fields, mixed $included_fields)
     : array {
-        if ($request->get('tabs', false)) {
-            $tabs = $request->get('tabs');
-            if (!is_array($request->get('tabs'))) {
-                $tabs = [$request->get('tabs')];
+        $tabs = $request->get('tabs', $request->get('tab', false));
+        if ($tabs) {
+            if (!is_array($tabs)) {
+                $tabs = [$tabs];
             }
             foreach ($tabs as $tab) {
                 $extra = explode(',', $tab);

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -89,6 +89,7 @@ class ContentJsonController extends Controller
         }
 
         $required_fields = $request->get('required_fields', []);
+        $included_fields = $request->get('included_fields', []);
 
         if ($request->has('term')) {
             $required_fields[] = 'name,%'.$request->get('term').'%,string,like';
@@ -125,6 +126,11 @@ class ContentJsonController extends Controller
             $required_fields[] = 'artist,%'.$request->get('title').'%,string,like';
         }elseif ($request->has('title') && $group_by == 'style') {
             $required_fields[] = 'style,%'.$request->get('title').'%,string,like';
+        }elseif ($request->has('title') && $group_by == 'instructor') {
+            $instructors = $this->contentService->getWhereTypeInAndStatusAndField(['instructor'], ['published'], 'name', '%'.$request->get('title').'%','string', 'LIKE');
+            foreach($instructors->pluck('id') ?? [] as $instructor){
+                $included_fields[] = 'instructor,'.$instructor.',integer,=';
+            }
         }else{
             $required_fields[] = 'title,%'.$request->get('title').'%,string,like';
         }
@@ -136,7 +142,7 @@ class ContentJsonController extends Controller
             $request->get('slug_hierarchy', []),
             $request->get('required_parent_ids', []),
             $required_fields,
-            $request->get('included_fields', []),
+            $included_fields,
             $request->get('required_user_states', []),
             $request->get('included_user_states', []),
             $request->get('include_filters', true),

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -115,6 +115,9 @@ class ContentJsonController extends Controller
                 if ($extra['0'] == 'duration') {
                     $required_fields[] = 'length_in_seconds,'.$extra[1].',integer,'.$extra[2].',video';
                 }
+                if ($extra['0'] == 'length_in_seconds') {
+                    $required_fields[] = $tab;
+                }
                 if ($extra['0'] == 'topic') {
                     $required_fields[] = 'topic,'.$extra[1].',string,'.$extra[2];
                 }

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -2,6 +2,7 @@
 
 namespace Railroad\Railcontent\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Log;
@@ -104,7 +105,9 @@ class ContentJsonController extends Controller
 
         $group_by = null;
         $contentTypes = $request->get('included_types', []);
-
+        if(count($contentTypes) > 5){
+            $required_fields[] = 'published_on,'.Carbon::now()->subMonth(3)->toDateTimeString().',date,>=';
+        }
         [$group_by, $required_fields, $included_fields] =
             $this->extractFields($request, $required_fields, $included_fields, $group_by);
 

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -97,10 +97,7 @@ class ContentJsonController extends Controller
             }
         }
 
-        if ($request->has('title')) {
-            $required_fields[] = 'title,%'.$request->get('title').'%,string,like';
-        }
-
+        $group_by = false;
         $contentTypes = $request->get('included_types', []);
         if($request->get('tab', false)){
             $tabs = $request->get('tab');
@@ -122,6 +119,14 @@ class ContentJsonController extends Controller
                     $required_fields[] = $tab;
                 }
             }
+        }
+
+        if ($request->has('title') && $group_by == 'artist') {
+            $required_fields[] = 'artist,%'.$request->get('title').'%,string,like';
+        }elseif ($request->has('title') && $group_by == 'style') {
+            $required_fields[] = 'style,%'.$request->get('title').'%,string,like';
+        }else{
+            $required_fields[] = 'title,%'.$request->get('title').'%,string,like';
         }
         $contentData = $this->contentService->getFiltered(
             $request->get('page', 1),

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -115,6 +115,9 @@ class ContentJsonController extends Controller
                 if ($extra['0'] == 'duration') {
                     $required_fields[] = 'length_in_seconds,'.$extra[1].',integer,'.$extra[2].',video';
                 }
+                if ($extra['0'] == 'topic') {
+                    $required_fields[] = 'topic,'.$extra[1].',string,'.$extra[2];
+                }
             }
         }
         $contentData = $this->contentService->getFiltered(

--- a/src/Controllers/ContentJsonController.php
+++ b/src/Controllers/ContentJsonController.php
@@ -119,7 +119,7 @@ class ContentJsonController extends Controller
                     $required_fields[] = $tab;
                 }
                 if ($extra['0'] == 'topic') {
-                    $required_fields[] = 'topic,'.$extra[1].',string,'.$extra[2];
+                    $required_fields[] = $tab;
                 }
             }
         }

--- a/src/Decorators/UserProgress/ContentUserProgressDecorator.php
+++ b/src/Decorators/UserProgress/ContentUserProgressDecorator.php
@@ -47,7 +47,9 @@ class ContentUserProgressDecorator implements DecoratorInterface
         $contentIds = [];
 
         foreach ($contents as $content) {
-            $contentIds[] = $content['id'];
+            if(isset($content['id'])) {
+                $contentIds[] = $content['id'];
+            }
         }
 
         $contents = $contents->toArray();

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1394,6 +1394,7 @@ class ContentRepository extends RepositoryBase
                     ->restrictByFields($this->requiredFields)
                     ->includeByFields($this->includedFields)
                     ->restrictByUserStates($this->requiredUserStates)
+                    ->includeByUserStates($this->includedUserStates)
                     ->groupByField($this->groupByFields);
             $query = $subQuery;
 
@@ -1528,6 +1529,7 @@ class ContentRepository extends RepositoryBase
                     ->restrictByFields($this->requiredFields)
                     ->includeByFields($this->includedFields)
                     ->restrictByUserStates($this->requiredUserStates)
+                    ->includeByUserStates($this->includedUserStates)
                     ->groupByField($this->groupByFields)
                     ->selectGroupedCountColumns($this->groupByFields);
 
@@ -1654,6 +1656,10 @@ class ContentRepository extends RepositoryBase
                     config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
                 ),
             ];
+        }
+        
+        if($name == 'type'){
+            $value = strtolower(str_replace(" ", "-", $value));
         }
 
         $bpmMapping = config('railcontent.bpm_map') ?? [];
@@ -3063,6 +3069,7 @@ class ContentRepository extends RepositoryBase
             'type' => ConfigService::$tableContent . '.type',
             'instrument' => ConfigService::$tableContent.'.instrument',
             'content_id' => ConfigService::$tableContent.'.id',
+            'instrumentless' => ConfigService::$tableContent.'.instrumentless',
         ];
 
         foreach ($filterOptionNameToContentTableColumnName as $filterOptionName => $filterOptionValue) {

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1639,8 +1639,8 @@ class ContentRepository extends RepositoryBase
     {
         $value = Arr::first(explode(' (', $value));
 
-        $mapping = config('railcontent.difficulty_map') ?? [];
-        $difficultyValues = array_keys($mapping, $value);
+        $difficultyMapping = config('railcontent.difficulty_map') ?? [];
+        $difficultyValues = array_keys($difficultyMapping, $value);
 
         foreach($difficultyValues ?? [] as $difficultyInt){
             $this->includedFields[] = [
@@ -1656,17 +1656,34 @@ class ContentRepository extends RepositoryBase
             ];
         }
 
-        $this->includedFields[] = [
-            'name' => $name,
-            'value' => $value,
-            'type' => $type,
-            'operator' => $operator,
-            'associated_table' => self::TABLESFORFIELDS[$name] ?? [],
-            'is_content_column' => in_array(
-                $name,
-                config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
-            ),
-        ];
+        $bpmMapping = config('railcontent.bpm_map') ?? [];
+        if(isset($bpmMapping[$value])){
+            $this->includedFields[] = [
+                'name' => $name,
+                'value' => $bpmMapping[$value]['min'],
+                'min' => $bpmMapping[$value]['min'],
+                'max' => $bpmMapping[$value]['max'],
+                'type' => 'integer',
+                'operator' => 'BETWEEN',
+                'associated_table' => self::TABLESFORFIELDS[$name] ?? [],
+                'is_content_column' => in_array(
+                    $name,
+                    config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
+                ),
+            ];
+        } else {
+            $this->includedFields[] = [
+                'name' => $name,
+                'value' => $value,
+                'type' => $type,
+                'operator' => $operator,
+                'associated_table' => self::TABLESFORFIELDS[$name] ?? [],
+                'is_content_column' => in_array(
+                    $name,
+                    config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
+                ),
+            ];
+        }
 
         return $this;
     }

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1394,6 +1394,9 @@ class ContentRepository extends RepositoryBase
                         ->addSubJoinToQuery($subQuery)
                         ->directPaginate($this->page, $this->limit)
                         ->orderBy('slug', 'asc');
+                if(!empty($this->typesToInclude)){
+                    $query->selectRaw(' "'.$this->typesToInclude[0].'" as content_type');
+                }
                 $contentRows = $query->getToArray();
                 $contentIds = $this->getGroupByContentIds($contentRows);
                 $dataLookup = $this->getContentLookupByIds($contentIds);
@@ -1407,6 +1410,11 @@ class ContentRepository extends RepositoryBase
 
                 return $contentRows;
             }
+
+            if(!empty($this->typesToInclude)){
+                $query->selectRaw(' "'.$this->typesToInclude[0].'" as content_type');
+            }
+
             if(!empty($this->groupByFields['associated_table'])) {
                 $orderBy = ($this->groupByFields['associated_table']['alias'] . '.' . $this->groupByFields['associated_table']['column']);
                 $contentRows = $query->selectRaw(' "'.$this->groupByFields['associated_table']['column'].'" as type')

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1441,12 +1441,12 @@ class ContentRepository extends RepositoryBase
                 $db->selectRaw(
                     'm.'.$this->groupByFields['associated_table']['column'].' as grouped_by_field,
                     m.'.$this->groupByFields['associated_table']['column'].' as id,	
-	                COUNT( DISTINCT(lessons.caontent_idd)) AS lessonsCount,
-	                GROUP_CONCAT(lessons.caontent_idd) as lessons_grouped_by_field, '.
+	                COUNT( DISTINCT(lessons.content_id)) AS lessonsCount,
+	                GROUP_CONCAT(lessons.content_id) as lessons_grouped_by_field, '.
                     ' "'.$this->groupByFields['associated_table']['column'].'" as type'
                 );
                 $rq =
-                    $query->selectRaw(' railcontent_content.id as caontent_idd')
+                    $query->selectRaw(' railcontent_content.id as content_id')
                         ->whereRaw('railcontent_content.id = m.content_id');
 
                 $contentRows =

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -117,7 +117,7 @@ class ContentRepository extends RepositoryBase
             'column' => 'instructor_id',
             'alias' => '_rci',
         ],
-        'style' => [
+        'genre' => [
             'table' => 'railcontent_content_styles',
             'column' => 'style',
             'alias' => '_rcs',
@@ -161,11 +161,6 @@ class ContentRepository extends RepositoryBase
             'table' => 'railcontent_content_gears',
             'column' => 'gear',
             'alias' => '_rcge',
-        ],
-        'genre' => [
-            'table' => 'railcontent_content_genres',
-            'column' => 'genre',
-            'alias' => '_rcgn',
         ],
     ];
 
@@ -2451,7 +2446,7 @@ class ContentRepository extends RepositoryBase
                 'column' => 'instructor_id',
                 'alias' => '_rci'
             ],
-            'style' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
+            'genre' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
@@ -2460,7 +2455,6 @@ class ContentRepository extends RepositoryBase
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
             'gear' => ['table' => 'railcontent_content_gears', 'column' => 'gear', 'alias' => '_rcge'],
-            'genre' => ['table' => 'railcontent_content_genres', 'column' => 'genre', 'alias' => '_rcgn'],
         ];
         if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) >= 1) {
             $brand = config('railcontent.brand');
@@ -2478,7 +2472,7 @@ class ContentRepository extends RepositoryBase
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
                 'instructor',
-                'style',
+                'genre',
                 'topic',
                 'focus',
                 'bpm',
@@ -2488,7 +2482,6 @@ class ContentRepository extends RepositoryBase
                 'lifestyle',
                 'type',
                 'gear',
-                'genre',
             ];
 
         $filterOptions = array_unique($filterOptions);
@@ -2955,7 +2948,7 @@ class ContentRepository extends RepositoryBase
                 'column' => 'instructor_id',
                 'alias' => '_rci'
             ],
-            'style' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
+            'genre' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
@@ -2964,7 +2957,6 @@ class ContentRepository extends RepositoryBase
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
             'gear' => ['table' => 'railcontent_content_gears', 'column' => 'gear', 'alias' => '_rcge'],
-            'genre' => ['table' => 'railcontent_content_genres', 'column' => 'genre', 'alias' => '_rcgn'],
         ];
 
         if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) >= 1) {
@@ -2982,7 +2974,7 @@ class ContentRepository extends RepositoryBase
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
                 'instructor',
-                'style',
+                'genre',
                 'topic',
                 'focus',
                 'bpm',
@@ -2992,7 +2984,6 @@ class ContentRepository extends RepositoryBase
                 'lifestyle',
                 'type',
                 'gear',
-                'genre'
             ];
 
         $filterOptions = array_unique($filterOptions);
@@ -3032,10 +3023,10 @@ class ContentRepository extends RepositoryBase
                 $this->includedFields = $initialFilters;
 
             foreach($tableResults ?? [] as $result){
-                $filterOptionsArray[$filterOptionColumnName][] = $result->grouped_by_value.' ('.$result->lessonsCount.')';
+                $filterOptionsArray[$filterOption][] = $result->grouped_by_value.' ('.$result->lessonsCount.')';
             }
-            if(isset($filterOptionsArray[$filterOptionColumnName])) {
-                usort($filterOptionsArray[$filterOptionColumnName], [$this, 'sortByAlphaThenNumeric']);
+            if(isset($filterOptionsArray[$filterOption])) {
+                usort($filterOptionsArray[$filterOption], [$this, 'sortByAlphaThenNumeric']);
             }
         }
 

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1601,6 +1601,11 @@ class ContentRepository extends RepositoryBase
                     ->unique();
 
             $possibleContentFields = $this->getFilterOptionsWithCounting($selectedFilterCategories);
+            foreach ($this->requiredFields as $requiredField){
+                if(array_key_exists($requiredField['name'], $possibleContentFields)){
+                    unset($possibleContentFields[$requiredField['name']]);
+                }
+            }
         }
 
         return $possibleContentFields;

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2959,15 +2959,13 @@ class ContentRepository extends RepositoryBase
                 if(in_array($filterOption, $selectedFilterCategories->toArray()))
                 {
                     $otherCategories = $includedFields->where('name', '!=', $filterOption);
-                    $this->includedFields =
-                    $otherCategories->values()
-                        ->toArray();
+                    $this->includedFields = $otherCategories->values()->toArray();
                 }
 
                 $db = DB::table($filterOptionTableName.' as m');
                 $db->selectRaw('m.'.$filterOptionColumnName.' as grouped_by_value,	
-	COUNT( * ) AS lessonsCount');
-                $rq = $this->query()->select('railcontent_content.id')
+	COUNT( DISTINCT(lessons.id)) AS lessonsCount');
+                $rq = $this->query()->selectRaw(' railcontent_content.id')
                     ->restrictByUserAccess()
                     ->restrictByFields($this->requiredFields)
                     ->includeByFields($this->includedFields)
@@ -2976,8 +2974,9 @@ class ContentRepository extends RepositoryBase
                     ->restrictByTypes($this->typesToInclude)
                     ->restrictByParentIds($this->requiredParentIds)
                     ->whereRaw('railcontent_content.id = m.content_id');
-                $tableResults = $db->joinLateral($rq, 'recent')->whereNotNull('recent.id')->groupBy('m.'.$filterOptionColumnName)->get() ;
-            $this->includedFields = $initialFilters;
+
+                $tableResults = $db->joinLateral($rq, 'lessons')->whereNotNull('lessons.id')->groupBy('m.'.$filterOptionColumnName)->get() ;
+                $this->includedFields = $initialFilters;
 
             foreach($tableResults ?? [] as $result){
                 $filterOptionsArray[$filterOptionColumnName][] = $result->grouped_by_value.' ('.$result->lessonsCount.')';

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2474,6 +2474,7 @@ class ContentRepository extends RepositoryBase
                 'theory',
                 'creativity',
                 'lifestyle',
+                'type',
             ];
 
         $filterOptions = array_unique($filterOptions);
@@ -2601,6 +2602,7 @@ class ContentRepository extends RepositoryBase
         $filterOptionNameToContentTableColumnName = [
             'difficulty' => ConfigService::$tableContent.'.difficulty',
             'artist' => ConfigService::$tableContent.'.artist',
+            'type' => ConfigService::$tableContent . '.type',
             'instrument' => ConfigService::$tableContent.'.instrument',
             'content_id' => ConfigService::$tableContent.'.id',
         ];

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1649,9 +1649,9 @@ class ContentRepository extends RepositoryBase
      * @param $userId null
      * @return $this
      */
-    public function requireUserStates($state, $userId = null)
+    public function requireUserStates($state, $userId = null,$operator = '=')
     {
-        $this->requiredUserStates[] = ['state' => $state, 'user_id' => $userId ?? auth()->id()];
+        $this->requiredUserStates[] = ['state' => $state, 'user_id' => $userId ?? auth()->id(), 'operator' => $operator];
 
         return $this;
     }

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -3051,6 +3051,7 @@ class ContentRepository extends RepositoryBase
                 ($this->typesToInclude[0] === 'song' ||
                     $this->typesToInclude[0] === 'course' ||
                     $this->typesToInclude[0] === 'rudiment' ||
+                    $this->typesToInclude[0] === 'song-tutorial' ||
                     $this->typesToInclude[0] === 'play-along') ? $this->typesToInclude[0].'s' :
                     $this->typesToInclude[0];
             $type = ($this->typesToInclude[0] === 'live') ? 'live-streams' : $type;

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -131,6 +131,26 @@ class ContentRepository extends RepositoryBase
             'column' => 'focus',
             'alias' => '_rcf',
         ],
+        'essentials' => [
+            'table' => 'railcontent_content_essentials',
+            'column' => 'essentials',
+            'alias' => '_rce',
+        ],
+        'theory' => [
+            'table' => 'railcontent_content_theory',
+            'column' => 'theory',
+            'alias' => '_rtb',
+        ],
+        'creativity' => [
+            'table' => 'railcontent_content_creativity',
+            'column' => 'creativity',
+            'alias' => '_rcc',
+        ],
+        'lifestyle' => [
+            'table' => 'railcontent_content_lifestyle',
+            'column' => 'lifestyle',
+            'alias' => '_rcl',
+        ],
         'bpm' => [
             'table' => 'railcontent_content_bpm',
             'column' => 'bpm',
@@ -2359,7 +2379,10 @@ class ContentRepository extends RepositoryBase
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
         ];
-
+if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) == 1){
+    $brand = config('railcontent.brand');
+    self::$catalogMetaAllowableFilters = (config('railcontent.cataloguesMetadata.'.$brand.'.'.$this->typesToInclude[0].'.allowableFilters'));
+}
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
                 'data',
                 'instructor',

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1691,6 +1691,17 @@ class ContentRepository extends RepositoryBase
         }
         elseif($name == 'type'){
             $value = strtolower(str_replace(" ", "-", $value));
+            $this->includedFields[] = [
+                'name' => $name,
+                'value' => $value,
+                'type' => $type,
+                'operator' => $operator,
+                'associated_table' => self::TABLESFORFIELDS[$name] ?? [],
+                'is_content_column' => in_array(
+                    $name,
+                    config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
+                ),
+            ];
         }elseif($name == 'bpm') {
             $bpmMapping = config('railcontent.bpm_map') ?? [];
             if (isset($bpmMapping[$value]) && isset($bpmMapping[$value]['min']) && isset($bpmMapping[$value]['max'])) {
@@ -3030,7 +3041,8 @@ class ContentRepository extends RepositoryBase
                     $difficultyArray = (explode(' (',$existOption));
                     $values[] = is_numeric($difficultyArray[0]) ? (int)$difficultyArray[0] : $difficultyArray[0];
                 }
-                if(!in_array($selected['value'], $values)){
+
+                if(!in_array(ucfirst($selected['value']), $values)){
                     $filterOptionsArray[$selected['name']][] = $selected['value'].' (0)';
                 }
             }

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2507,6 +2507,7 @@ class ContentRepository extends RepositoryBase
                 'alias' => '_rci'
             ],
             'genre' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
+            'style' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcso'],
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1568,10 +1568,10 @@ class ContentRepository extends RepositoryBase
             ->addBinding($subQuery->getBindings())
             ->count();
         
-        //All lessons page should display max 100 lessons
-        if(count($this->typesToInclude) > 10 && $count > 100){
-            return 100;
-        }
+//        //All lessons page should display max 100 lessons
+//        if(count($this->typesToInclude) > 10 && $count > 100){
+//            return 100;
+//        }
         return $count;
     }
 
@@ -1693,7 +1693,7 @@ class ContentRepository extends RepositoryBase
             $value = strtolower(str_replace(" ", "-", $value));
         }elseif($name == 'bpm') {
             $bpmMapping = config('railcontent.bpm_map') ?? [];
-            if (isset($bpmMapping[$value])) {
+            if (isset($bpmMapping[$value]) && isset($bpmMapping[$value]['min']) && isset($bpmMapping[$value]['max'])) {
                 $this->includedFields[] = [
                     'name' => $name,
                     'value' => $bpmMapping[$value]['min'],

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1569,9 +1569,11 @@ class ContentRepository extends RepositoryBase
                     $this->includedFields = $initialFilters;
             }
 
-            foreach ($possibleContentFields as $possibleContentFieldKey => $possibleContentFieldValue) {
-                if (isset($myResults[$possibleContentFieldKey])) {
-                    $possibleContentFields[$possibleContentFieldKey] = $myResults[$possibleContentFieldKey];
+            if(!empty($selectedFilterCategories ?? [])) {
+                foreach ($possibleContentFields as $possibleContentFieldKey => $possibleContentFieldValue) {
+                    if (isset($myResults[$possibleContentFieldKey])) {
+                        $possibleContentFields[$possibleContentFieldKey] = $myResults[$possibleContentFieldKey];
+                    }
                 }
             }
         }

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -124,7 +124,7 @@ class ContentRepository extends RepositoryBase
         'topic' => [
             'table' => 'railcontent_content_topics',
             'column' => 'topic',
-            'alias' => '_rct',
+            'alias' => '_rctt',
         ],
         'focus' => [
             'table' => 'railcontent_content_focus',
@@ -139,7 +139,7 @@ class ContentRepository extends RepositoryBase
         'theory' => [
             'table' => 'railcontent_content_theory',
             'column' => 'theory',
-            'alias' => '_rtb',
+            'alias' => '_rth',
         ],
         'creativity' => [
             'table' => 'railcontent_content_creativity',
@@ -2419,7 +2419,7 @@ class ContentRepository extends RepositoryBase
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
             'essentials' => ['table' => 'railcontent_content_essentials', 'column' => 'essentials', 'alias' => '_rce'],
-            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rct'],
+            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rcth'],
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
         ];
@@ -2429,11 +2429,15 @@ if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) == 1){
 }
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
                 'data',
-                'instructor',
+//                'instructor',
                 'style',
                 'topic',
                 'focus',
                 'bpm',
+            'essentials',
+            'theory',
+            'creativity',
+            'lifestyle'
             ];
 
         // we always need the related data
@@ -2932,18 +2936,23 @@ if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) == 1){
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
             'essentials' => ['table' => 'railcontent_content_essentials', 'column' => 'essentials', 'alias' => '_rce'],
-            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rct'],
+            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rcth'],
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
         ];
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
             'data',
-            'instructor',
+         //   'instructor',
             'style',
             'topic',
             'focus',
             'bpm',
+            'essentials',
+            'theory',
+            'creativity',
+            'lifestyle'
+
         ];
 
         // we always need the related data

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2906,6 +2906,7 @@ class ContentRepository extends RepositoryBase
                 'alias' => '_rci'
             ],
             'genre' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
+            'style' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcsss'],
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -157,6 +157,16 @@ class ContentRepository extends RepositoryBase
             'column' => 'bpm',
             'alias' => '_rcb',
         ],
+        'gear' => [
+            'table' => 'railcontent_content_gears',
+            'column' => 'gear',
+            'alias' => '_rcge',
+        ],
+        'genre' => [
+            'table' => 'railcontent_content_genres',
+            'column' => 'genre',
+            'alias' => '_rcgn',
+        ],
     ];
 
     /**
@@ -2449,6 +2459,8 @@ class ContentRepository extends RepositoryBase
             'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rcth'],
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
+            'gear' => ['table' => 'railcontent_content_gears', 'column' => 'gear', 'alias' => '_rcge'],
+            'genre' => ['table' => 'railcontent_content_genres', 'column' => 'genre', 'alias' => '_rcgn'],
         ];
         if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) >= 1) {
             $brand = config('railcontent.brand');
@@ -2475,6 +2487,8 @@ class ContentRepository extends RepositoryBase
                 'creativity',
                 'lifestyle',
                 'type',
+                'gear',
+                'genre',
             ];
 
         $filterOptions = array_unique($filterOptions);
@@ -2949,6 +2963,8 @@ class ContentRepository extends RepositoryBase
             'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rcth'],
             'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
             'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
+            'gear' => ['table' => 'railcontent_content_gears', 'column' => 'gear', 'alias' => '_rcge'],
+            'genre' => ['table' => 'railcontent_content_genres', 'column' => 'genre', 'alias' => '_rcgn'],
         ];
 
         if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) >= 1) {
@@ -2975,6 +2991,8 @@ class ContentRepository extends RepositoryBase
                 'creativity',
                 'lifestyle',
                 'type',
+                'gear',
+                'genre'
             ];
 
         $filterOptions = array_unique($filterOptions);

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1534,7 +1534,7 @@ class ContentRepository extends RepositoryBase
                     ->restrictByUserStates($this->requiredUserStates)
                     ->includeByUserStates($this->includedUserStates)
                     ->groupByField($this->groupByFields)
-                    ->selectGroupedCountColumns($this->groupByFields);
+                    ->selectGroupedColumnsForCount($this->groupByFields);
 
             return $this->connection()
                 ->table(

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2636,7 +2636,7 @@ class ContentRepository extends RepositoryBase
         $contentIds = [];
         foreach ($contentRows as $contentRow) {
             $ids =  explode(',',$contentRow['lessons_grouped_by_field']);
-            $contentIds = array_merge($contentIds, array_slice($ids,0,5));
+            $contentIds = array_merge($contentIds, $ids);
         }
         $contentIds = array_unique($contentIds);
         return $contentIds;

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1611,6 +1611,23 @@ class ContentRepository extends RepositoryBase
     {
         $value = Arr::first(explode(' (', $value));
 
+        $mapping = config('railcontent.difficulty_map') ?? [];
+        $difficultyValues = array_keys($mapping, $value);
+
+        foreach($difficultyValues ?? [] as $difficultyInt){
+            $this->includedFields[] = [
+                'name' => $name,
+                'value' => $difficultyInt,
+                'type' => $type,
+                'operator' => $operator,
+                'associated_table' => self::TABLESFORFIELDS[$name] ?? [],
+                'is_content_column' => in_array(
+                    $name,
+                    config('railcontent.content_fields_that_are_now_columns_in_the_content_table', [])
+                ),
+            ];
+        }
+
         $this->includedFields[] = [
             'name' => $name,
             'value' => $value,

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1405,7 +1405,7 @@ class ContentRepository extends RepositoryBase
                         ->addSubJoinToQuery($subQuery)
                         ->directPaginate($this->page, $this->limit)
                         ->orderBy('slug', $this->orderDirection);
-                if (!empty($this->typesToInclude)) {
+                if (!empty($this->typesToInclude) && (count($this->typesToInclude) <= 3)) {
                     $query->selectRaw(' "'.$this->typesToInclude[0].'" as content_type');
                 }
                 $contentRows = $query->getToArray();
@@ -2981,17 +2981,21 @@ class ContentRepository extends RepositoryBase
             'gear' => ['table' => 'railcontent_content_gears', 'column' => 'gear', 'alias' => '_rcge'],
         ];
 
+        $brand = config('railcontent.brand');
         if (!self::$catalogMetaAllowableFilters && count($this->typesToInclude) >= 1) {
-            $brand = config('railcontent.brand');
-            $type =
+              $type =
                 ($this->typesToInclude[0] === 'song' ||
                     $this->typesToInclude[0] === 'course' ||
                     $this->typesToInclude[0] === 'rudiment' ||
                     $this->typesToInclude[0] === 'play-along') ? $this->typesToInclude[0].'s' : $this->typesToInclude[0];
             $type = ($this->typesToInclude[0] === 'live') ? 'live-streams' : $type;
             $type = ($this->typesToInclude[0] === 'instructor') ? 'coaches' : $type;
+            $type = (count($this->typesToInclude) > 3) ? 'all' : $type;
             self::$catalogMetaAllowableFilters =
                 (config('railcontent.cataloguesMetadata.'.$brand.'.'.$type.'.allowableFilters'));
+        }elseif (in_array('instructor', Arr::pluck($this->requiredFields,'name'))){
+            self::$catalogMetaAllowableFilters =
+                (config('railcontent.cataloguesMetadata.'.$brand.'.coach-lessons.allowableFilters'));
         }
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1426,7 +1426,8 @@ class ContentRepository extends RepositoryBase
                         ->getPostProcessor()
                 ))->from($this->groupByFields['associated_table']['table'].' as m');
                 $db->selectRaw(
-                    'm.'.$this->groupByFields['associated_table']['column'].' as grouped_by_field,	
+                    'm.'.$this->groupByFields['associated_table']['column'].' as grouped_by_field,
+                    m.'.$this->groupByFields['associated_table']['column'].' as id,	
 	                COUNT( DISTINCT(lessons.caontent_idd)) AS lessonsCount,
 	                GROUP_CONCAT(lessons.caontent_idd) as lessons_grouped_by_field, '.
                     ' "'.$this->groupByFields['associated_table']['column'].'" as type'

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2436,6 +2436,11 @@ class ContentRepository extends RepositoryBase
 
         // get values that are in other tables
         $filterNameToTableNameAndColumnName = [
+            'instructor' => [
+                'table' => 'railcontent_content_instructors',
+                'column' => 'instructor_id',
+                'alias' => '_rci'
+            ],
             'style' => ['table' => 'railcontent_content_styles', 'column' => 'style', 'alias' => '_rcs'],
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
@@ -2451,16 +2456,20 @@ class ContentRepository extends RepositoryBase
             $type =
                 ($this->typesToInclude[0] === 'song' ||
                     $this->typesToInclude[0] === 'course' ||
-                    $this->typesToInclude[0] === 'rudiment') ? $this->typesToInclude[0].'s' : $this->typesToInclude[0];
+                    $this->typesToInclude[0] === 'rudiment' ||
+                    $this->typesToInclude[0] === 'play-along') ? $this->typesToInclude[0].'s' : $this->typesToInclude[0];
             $type = ($this->typesToInclude[0] === 'live') ? 'live-streams' : $type;
+            $type = ($this->typesToInclude[0] === 'instructor') ? 'coaches' : $type;
             self::$catalogMetaAllowableFilters =
                 (config('railcontent.cataloguesMetadata.'.$brand.'.'.$type.'.allowableFilters'));
         }
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
+                'instructor',
                 'style',
                 'topic',
                 'focus',
+                'bpm',
                 'essentials',
                 'theory',
                 'creativity',

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -2354,6 +2354,10 @@ class ContentRepository extends RepositoryBase
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
+            'essentials' => ['table' => 'railcontent_content_essentials', 'column' => 'essentials', 'alias' => '_rce'],
+            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rct'],
+            'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
+            'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
         ];
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [
@@ -2831,6 +2835,10 @@ class ContentRepository extends RepositoryBase
             'topic' => ['table' => 'railcontent_content_topics', 'column' => 'topic', 'alias' => '_rct'],
             'focus' => ['table' => 'railcontent_content_focus', 'column' => 'focus', 'alias' => '_rcf'],
             'bpm' => ['table' => 'railcontent_content_bpm', 'column' => 'bpm', 'alias' => '_rcb'],
+            'essentials' => ['table' => 'railcontent_content_essentials', 'column' => 'essentials', 'alias' => '_rce'],
+            'theory' => ['table' => 'railcontent_content_theory', 'column' => 'theory', 'alias' => '_rct'],
+            'creativity' => ['table' => 'railcontent_content_creativity', 'column' => 'creativity', 'alias' => '_rcc'],
+            'lifestyle' => ['table' => 'railcontent_content_lifestyle', 'column' => 'lifestyle', 'alias' => '_rcl'],
         ];
 
         $filterOptions = self::$catalogMetaAllowableFilters ?? [

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -162,6 +162,11 @@ class ContentRepository extends RepositoryBase
             'column' => 'gear',
             'alias' => '_rcge',
         ],
+        'style' => [
+            'table' => 'railcontent_content_styles',
+            'column' => 'style',
+            'alias' => '_rcs',
+        ],
     ];
 
     /**

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1393,7 +1393,7 @@ class ContentRepository extends RepositoryBase
                         ->addSelect('inner_content.lessons_grouped_by_field as lessons_grouped_by_field')
                         ->addSubJoinToQuery($subQuery)
                         ->directPaginate($this->page, $this->limit)
-                        ->orderBy('slug', 'asc');
+                        ->orderBy('slug', $this->orderDirection);
                 if (!empty($this->typesToInclude)) {
                     $query->selectRaw(' "'.$this->typesToInclude[0].'" as content_type');
                 }
@@ -1423,13 +1423,13 @@ class ContentRepository extends RepositoryBase
                 $contentRows =
                     $query->selectRaw(' "'.$this->groupByFields['associated_table']['column'].'" as type')
                         ->directPaginate($this->page, $this->limit)
-                        ->orderByRaw($orderBy.' asc')
+                        ->orderByRaw($orderBy.' '.$this->orderDirection)
                         ->getToArray();
             } else {
                 $contentRows =
                     $query->selectRaw(' "'.$this->groupByFields['field'].'" as type')
                         ->directPaginate($this->page, $this->limit)
-                        ->orderByRaw($this->groupByFields['field'].' asc')
+                        ->orderByRaw($this->groupByFields['field'].' '.$this->orderDirection)
                         ->getToArray();
             }
 

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -3020,6 +3020,22 @@ class ContentRepository extends RepositoryBase
             usort($filterOptionsArray[$filterOptionName], [$this, 'sortByAlphaThenNumeric']);
         }
 
+        //Return Currently Selected Filter(s), regardless of number of results
+        foreach($initialFilters as $selected) {
+            if(!isset($filterOptionsArray[$selected['name']])){
+                $filterOptionsArray[$selected['name']][] = $selected['value'].' (0)';
+            }else{
+                $values = [];
+                foreach($filterOptionsArray[$selected['name']] as $existOption) {
+                    $difficultyArray = (explode(' (',$existOption));
+                    $values[] = is_numeric($difficultyArray[0]) ? (int)$difficultyArray[0] : $difficultyArray[0];
+                }
+                if(!in_array($selected['value'], $values)){
+                    $filterOptionsArray[$selected['name']][] = $selected['value'].' (0)';
+                }
+            }
+        }
+
         return $filterOptionsArray;
     }
 

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -466,7 +466,18 @@ class ContentQueryBuilder extends QueryBuilder
 
         foreach ($includedFields as $includedFieldIndex => $includedField) {
             if (!empty($includedField['associated_table']['table'])) {
-                $includedFieldsGroupedByTable[$includedField['associated_table']['table']][] = $includedField;
+                $joinExists = false;
+
+                foreach($this->joins ?? [] as $join)
+                {
+                    if($join->table == $includedField['associated_table']['table'].' as '.$includedField['associated_table']['alias'])
+                    {
+                        $joinExists = true;
+                    }
+                }
+                if(!$joinExists) {
+                    $includedFieldsGroupedByTable[$includedField['associated_table']['table']][] = $includedField;
+                }
             } else {
                 $includedFieldsGroupedByTable[$includedField['name']][] = $includedField;
             }

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -823,4 +823,23 @@ class ContentQueryBuilder extends QueryBuilder
 
         return $this;
     }
+
+    public function selectGroupedCountColumns($groupBy)
+    {
+        $isTableContent = $groupBy['is_content_column'] ?? false;
+        $alias = ConfigService::$tableContent;
+        $field = 'id';
+
+        if ($isTableContent) {
+            $field = $groupBy['field'];
+        } elseif(!empty($groupBy['associated_table'])) {
+            $field = $groupBy['associated_table']['column'];
+            $alias = $groupBy['associated_table']['alias'];
+        }
+        $this->select([
+                             $this->raw('DISTINCT('. $alias.'.'.$field.') as id'),
+                         ]);
+
+        return $this;
+    }
 }

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -867,7 +867,7 @@ class ContentQueryBuilder extends QueryBuilder
         return $this;
     }
 
-    public function selectGroupedCountColumns($groupBy)
+    public function selectGroupedColumnsForCount($groupBy)
     {
         $isTableContent = $groupBy['is_content_column'] ?? false;
         $alias = ConfigService::$tableContent;

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -314,7 +314,7 @@ class ContentQueryBuilder extends QueryBuilder
                         )
                         ->on(
                             $tableName.'.state',
-                            '=',
+                            $requiredUserState['operator'],
                             $joinClause->raw(
                                 DB::connection()
                                     ->getPdo()

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -783,7 +783,7 @@ class ContentQueryBuilder extends QueryBuilder
                                  DB::raw(
                                      "( 
            JSON_ARRAYAGG(
-            id
+            ".ConfigService::$tableContent.".id
         ) ) as lessons_grouped_by_field"
                                  ),
                              ])

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -781,8 +781,8 @@ class ContentQueryBuilder extends QueryBuilder
                                  $this->raw(ConfigService::$tableContent.'.'.$field.' as grouped_by_field'),
 
                                  DB::raw(
-                                     "( 
-           JSON_ARRAYAGG(
+                                     "(
+            GROUP_CONCAT(
             ".ConfigService::$tableContent.".id
         ) ) as lessons_grouped_by_field"
                                  ),
@@ -807,7 +807,7 @@ class ContentQueryBuilder extends QueryBuilder
                              $this->raw($alias.'.'.$field.' as id'),
                              DB::raw(
                                  "( 
-           JSON_ARRAYAGG(
+           GROUP_CONCAT(
             ".$alias.".content_id      
         ) ) as lessons_grouped_by_field"
                              ),

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -801,8 +801,16 @@ class ContentQueryBuilder extends QueryBuilder
         $table = $groupBy['associated_table']['table'];
         $field = $groupBy['associated_table']['column'];
         $alias = $groupBy['associated_table']['alias'];
+        $joinExists = false;
 
-        $this->addSelect([
+        foreach($this->joins ?? [] as $join)
+        {
+            if($join->table == $table.' as '.$alias)
+            {
+              $joinExists = true;
+            }
+        }
+       $this->addSelect([
                              $this->raw($alias.'.'.$field.' as grouped_by_field'),
                              $this->raw($alias.'.'.$field.' as id'),
                              DB::raw(
@@ -811,14 +819,19 @@ class ContentQueryBuilder extends QueryBuilder
             ".$alias.".content_id      
         ) ) as lessons_grouped_by_field"
                              ),
-                         ])
-            ->join(
+                         ]);
+        
+        if(!$joinExists) {
+            $this->
+            join(
                 $table.' as '.$alias,
                 $alias.'.'.'content_id',
                 '=',
                 ConfigService::$tableContent.'.id'
-            )
-            ->whereNotNull($alias.'.'.$field)
+            );
+        }
+
+        $this->whereNotNull($alias.'.'.$field)
             ->groupBy($alias.'.'.$field);
 
         return $this;

--- a/src/Repositories/QueryBuilders/ContentQueryBuilder.php
+++ b/src/Repositories/QueryBuilders/ContentQueryBuilder.php
@@ -779,7 +779,7 @@ class ContentQueryBuilder extends QueryBuilder
             $this->addSelect([
                                  $this->raw(ConfigService::$tableContent.'.'.$field.' as '.$field),
                                  $this->raw(ConfigService::$tableContent.'.'.$field.' as grouped_by_field'),
-
+                                 $this->raw(ConfigService::$tableContent.'.'.$field.' as id'),
                                  DB::raw(
                                      "(
             GROUP_CONCAT(

--- a/src/Repositories/UserContentProgressRepository.php
+++ b/src/Repositories/UserContentProgressRepository.php
@@ -362,4 +362,29 @@ class UserContentProgressRepository extends RepositoryBase
             ->first()['count'];
     }
 
+    public function countByArtistTypesUserProgress(array $types, $artist)
+    {
+        $query =  $this->query()
+            ->select(
+                $this->databaseManager->raw(
+                    'COUNT(' . ConfigService::$tableUserContentProgress . '.id) as count'
+                )
+            )
+            ->join(
+                ConfigService::$tableContent,
+                function (JoinClause $join) {
+                    $join->on(
+                        ConfigService::$tableContent . '.id',
+                        '=',
+                        ConfigService::$tableUserContentProgress . '.content_id'
+                    );
+                }
+            )
+            ->whereIn(ConfigService::$tableContent . '.type', $types)
+            ->where(ConfigService::$tableContent . '.artist', $artist);
+
+        return $query->get()
+            ->first()['count'];
+    }
+
 }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1051,10 +1051,10 @@ class ContentService
             }
 
             $resultsDB = new ContentFilterResultsEntity([
-                                                                'results' => $filter->retrieveFilter(),
-                                                                'total_results' => $pullPagination ?
-                                                                    $filter->countFilter() : 0,
-                                                                'filter_options' => $pullFilterFields ? $this->getFilterOptions($filter, $includedTypes) : [],
+                'results' => $filter->retrieveFilter(),
+                'total_results' => $pullPagination ?
+                    $filter->countFilter() : 0,
+                'filter_options' => $pullFilterFields ? $this->getFilterOptions($filter, $includedTypes) : [],
                                                             ]);
 
             $results = CacheHelper::saveUserCache($hash, $resultsDB, Arr::pluck($resultsDB['results'], 'id'));

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -2860,11 +2860,22 @@ class ContentService
         return $filters['difficulty'];
     }
 
+    /**
+     * Mapping system for BPM filter options
+     * Should take into consideration the mapping rules:
+    '50-90' => ['min' => 50, 'max' => 90],
+    '91-120' => ['min' => 91, 'max' => 120],
+    '121-150' => ['min' => 121, 'max' => 150],
+    '151-180' => ['min' => 151, 'max' => 180],
+    '181+' => ['min' => 181, 'max' => 10000],
+     * @param $bpmOptions - is an array with the format: "bpm_value (number_or_lessons)"
+     * @return array
+     */
     private function bpmFilterOptionsMapping($bpmOptions)
     {
         $mappedBpm = [];
-        foreach ($bpmOptions as $index => $difficultyS) {
-            $bpmArray = (explode(' (', $difficultyS));
+        foreach ($bpmOptions as $bpmOption) {
+            $bpmArray = (explode(' (', $bpmOption));
             $bpm = is_numeric($bpmArray[0]) ? (int)$bpmArray[0] : $bpmArray[0];
             $nr = str_replace(')', '', $bpmArray[1]);
             $mappingOptions = config('railcontent.bpm_map') ?? [];

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1149,9 +1149,9 @@ class ContentService
                 $results = new ContentFilterResultsEntity($results);
             }
         }
+        $decorator = ($groupBy) ? 'group':'content';
 
-
-        return Decorator::decorate($results, 'content');
+        return Decorator::decorate($results, $decorator);
     }
 
     // for remove extraneous options and order logically rather than alphabetically

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1215,8 +1215,8 @@ class ContentService
         $filterFields = $pullFilterFields ? $filter->getFilterFields() : [];
         if ($pullFilterFields && !empty($filterFields['difficulty'])) {
             if (ContentRepository::$countFilterOptionItems == 1) {
-                $filterFields['difficulty'] = $this->difficultyFilterOptionsMapping(
-                    $filterFields['difficulty']
+                $filterFields['difficulty'] = $this->filterOptionsMapping(
+                    $filterFields['difficulty'], 'railcontent.difficulty_map'
                 );
             } else {
                 $filterFields['difficulty'] = $this->difficultyFilterOptionsCleanup(
@@ -1237,6 +1237,14 @@ class ContentService
         if ($pullFilterFields && !empty($filterFields['type'])) {
             if (ContentRepository::$countFilterOptionItems == 1) {
                 $filterFields['type'] = array_map(function($m) { return ucwords(str_replace("-", " ", $m));}, $filterFields['type']);
+            }
+        }
+
+        if ($pullFilterFields && !empty($filterFields['instrumentless'])) {
+            if (ContentRepository::$countFilterOptionItems == 1) {
+                $filterFields['instrumentless'] = $this->filterOptionsMapping(
+                    $filterFields['instrumentless'], 'railcontent.instrumentless_map.'.config('railcontent.brand')
+                );
             }
         }
 
@@ -2953,14 +2961,14 @@ class ContentService
         return $results;
     }
 
-    private function difficultyFilterOptionsMapping($difficultyOptions)
+    private function filterOptionsMapping($difficultyOptions, $rules = 'railcontent.difficulty_map')
     {
         $mappedDifficulty = [];
         foreach ($difficultyOptions as $index => $difficultyS) {
             $difficultyArray = (explode(' (', $difficultyS));
             $difficulty = is_numeric($difficultyArray[0]) ? (int)$difficultyArray[0] : $difficultyArray[0];
             $difficultyNr = str_replace(')', '', $difficultyArray[1]);
-            $mapping = config('railcontent.difficulty_map') ?? [];
+            $mapping = config($rules) ?? [];
             if (!empty($mapping[$difficulty] ?? [])) {
                 $mappedDifficulty[$mapping[$difficulty]] =
                     ($mappedDifficulty[$mapping[$difficulty]] ?? 0) + $difficultyNr;

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1134,7 +1134,7 @@ class ContentService
                 if($groupBy) {
                     foreach ($res as $i => $v) {
                         if (!empty($v['lessons'] ?? [])) {
-                            $res[$i]['lessons'] = (Decorator::decorate($v['lessons'], 'content'));
+                            $res[$i]['lessons'] = (Decorator::decorate($v['lessons'], 'card'));
                         }
                     }
                 }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1130,9 +1130,16 @@ class ContentService
                         $filterFields['difficulty']
                     );
                 }
-
+                $res = $filter->retrieveFilter();
+                if($groupBy) {
+                    foreach ($res as $i => $v) {
+                        if (!empty($v['lessons'] ?? [])) {
+                            $res[$i]['lessons'] = (Decorator::decorate($v['lessons'], 'content'));
+                        }
+                    }
+                }
                 $resultsDB = new ContentFilterResultsEntity([
-                                                                'results' => $filter->retrieveFilter(),
+                                                                'results' => $res,
                                                                 'total_results' => $pullPagination ?
                                                                     $filter->countFilter() : 0,
                                                                 'filter_options' => $filterFields,

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -2949,11 +2949,14 @@ class ContentService
                 $mappedDifficulty[$difficulty] = $difficultyNr;
             }
         }
+        $order = array('-','All','Novice','Beginner', 'Intermediate', 'Advanced', 'Expert');
+        $properOrderedArray = array_merge(array_fill_keys($order, 0), $mappedDifficulty);
         $filters['difficulty'] = [];
-        foreach ($mappedDifficulty as $difficulty => $count) {
-            $filters['difficulty'][] = $difficulty.' ('.$count.')';
+        foreach ($properOrderedArray as $difficulty => $count) {
+            if($count != 0) {
+                $filters['difficulty'][] = $difficulty.' ('.$count.')';
+            }
         }
-        sort($filters['difficulty'], SORT_STRING);
 
         return $filters['difficulty'];
     }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -2820,6 +2820,22 @@ class ContentService
     private function filterOptionsMapping($difficultyOptions, $rules = 'railcontent.difficulty_map')
     {
         $mappedDifficulty = [];
+
+        //DifficultyOptions is an array with the format: "difficulty_level (number_or_lessons)"
+        //$difficultyOptions = [
+        //  0 => "1 (6)",
+        //  1 => "10 (5)",
+        //  2 => "2 (34)",
+        //  3 => "3 (103)",
+        //  4 => "4 (294)",
+        //  5 => "5 (528)",
+        //  6 => "6 (215)",
+        //  7 => "7 (71)",
+        //  8 => "8 (30)",
+        //  9 => "9 (12)",
+        //]
+        // We need to provide the "difficulty_string (number_of_lessons)"
+        // and take care that some difficulty strings like Intermediate summarize different difficulty_level
         foreach ($difficultyOptions as $index => $difficultyS) {
             $difficultyArray = (explode(' (', $difficultyS));
             $difficulty = is_numeric($difficultyArray[0]) ? (int)$difficultyArray[0] : $difficultyArray[0];
@@ -2836,7 +2852,7 @@ class ContentService
         $properOrderedArray = array_merge(array_fill_keys($order, 0), $mappedDifficulty);
         $filters['difficulty'] = [];
         foreach ($properOrderedArray as $difficulty => $count) {
-            if($count != 0) {
+            if($count != 0 || array_key_exists($difficulty, $mappedDifficulty)) {
                 $filters['difficulty'][] = $difficulty.' ('.$count.')';
             }
         }
@@ -2848,14 +2864,14 @@ class ContentService
     {
         $mappedBpm = [];
         foreach ($bpmOptions as $index => $difficultyS) {
-            $difficultyArray = (explode(' (', $difficultyS));
-            $difficulty = is_numeric($difficultyArray[0]) ? (int)$difficultyArray[0] : $difficultyArray[0];
-            $difficultyNr = str_replace(')', '', $difficultyArray[1]);
+            $bpmArray = (explode(' (', $difficultyS));
+            $bpm = is_numeric($bpmArray[0]) ? (int)$bpmArray[0] : $bpmArray[0];
+            $nr = str_replace(')', '', $bpmArray[1]);
             $mappingOptions = config('railcontent.bpm_map') ?? [];
             foreach($mappingOptions as $key=>$mappingOption){
-                if($difficulty >= $mappingOption['min'] && $difficulty <= $mappingOption['max']){
+                if($bpm >= $mappingOption['min'] && $bpm <= $mappingOption['max']){
                     $mappedBpm[$key] =
-                        ($mappedBpm[$key] ?? 0) + $difficultyNr;
+                        ($mappedBpm[$key] ?? 0) + $nr;
                 }
             }
         }
@@ -2863,7 +2879,7 @@ class ContentService
         $properOrderedArray = array_merge(array_fill_keys($order, 0), $mappedBpm);
         $filters['bpm'] = [];
         foreach ($properOrderedArray as $bpm => $count) {
-            if($count != 0) {
+            if($count != 0 || array_key_exists($bpm, $mappedBpm)) {
                 $filters['bpm'][] = $bpm.' ('.$count.')';
             }
         }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1234,6 +1234,12 @@ class ContentService
             }
         }
 
+        $order = ContentRepository::$catalogMetaAllowableFilters;
+
+        if($order) {
+            $filterFields = array_merge(array_fill_keys($order, 0), $filterFields);
+        }
+
         return $filterFields;
     }
 

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1234,6 +1234,12 @@ class ContentService
             }
         }
 
+        if ($pullFilterFields && !empty($filterFields['type'])) {
+            if (ContentRepository::$countFilterOptionItems == 1) {
+                $filterFields['type'] = array_map(function($m) { return ucwords(str_replace("-", " ", $m));}, $filterFields['type']);
+            }
+        }
+
         $order = ContentRepository::$catalogMetaAllowableFilters;
 
         if($order) {

--- a/src/Services/UserContentProgressService.php
+++ b/src/Services/UserContentProgressService.php
@@ -752,4 +752,12 @@ class UserContentProgressService
     {
         return $this->userContentRepository->countContentProgress($contentId, $date, $state);
     }
+
+    public function countByArtistTypesUserProgress(array $types, $artist)
+    {
+        return $this->userContentRepository->countByArtistTypesUserProgress(
+            $types,
+            $artist
+        );;
+    }
 }

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -166,8 +166,8 @@ class ContentCompiledColumnTransformer
             $lessonContentIds = explode(',', $lessons);
             $lessonContentIds = array_unique($lessonContentIds);
             $allLessonsCount = count($lessonContentIds);
-            $lessonContentIds = (array_slice($lessonContentIds,0,5));
-            $contentRows[$contentRowIndex]['all_lessons_count'] = $allLessonsCount;
+            $lessonContentIds = (array_slice($lessonContentIds,0,10));
+            $contentRows[$contentRowIndex]['all_lessons_count'] = $contentRow['lessonsCount'] ?? $allLessonsCount;
 
 
             if (empty($lessonContentIds)) {

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -174,7 +174,7 @@ class ContentCompiledColumnTransformer
                 continue;
             }
 
-            if($contentRow['type'] == 'style'){
+            if($contentRow['type'] == 'style' || $contentRow['type'] == 'artist'){
                 $contentRows[$contentRowIndex]['data'][] = [
                     'id' => substr(md5(mt_rand()), 0, 10),
                     'content_id' =>substr(md5(mt_rand()), 0, 10),

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -11,7 +11,7 @@ class ContentCompiledColumnTransformer
     public static bool $avoidDuplicates = false;
 
     /**
-     * @param  array|null  $contentRows
+     * @param array|null $contentRows
      * @return array
      */
     public function transform(array $contentRows = null)
@@ -39,7 +39,7 @@ class ContentCompiledColumnTransformer
 
             $contentRows[$contentRowIndex]['data'] = [];
             $contentRows[$contentRowIndex]['fields'] = [];
-          //  $contentRows[$contentRowIndex]['permissions'] = [];
+            //  $contentRows[$contentRowIndex]['permissions'] = [];
 
             if (empty($contentRowCompiledColumnValues)) {
                 continue;
@@ -68,7 +68,7 @@ class ContentCompiledColumnTransformer
                                 'position' => $dataKeyCounts[$dataKey],
                             ];
                         }
-                        if(self::$avoidDuplicates){
+                        if (self::$avoidDuplicates) {
                             unset($contentRows[$contentRowIndex][$dataKey]);
                         }
                     }
@@ -98,7 +98,7 @@ class ContentCompiledColumnTransformer
                                 'type' => 'string',
                                 'position' => $fieldKeyCounts[$fieldKey],
                             ];
-                            if(self::$avoidDuplicates){
+                            if (self::$avoidDuplicates) {
                                 unset($contentRows[$contentRowIndex][$fieldKey]);
                             }
                         }
@@ -118,10 +118,10 @@ class ContentCompiledColumnTransformer
                                 'type' => 'content',
                                 'position' => $fieldKeyCounts[$fieldKey],
                             ];
-                            if(self::$avoidDuplicates){
+                            if (self::$avoidDuplicates) {
                                 unset($contentRows[$contentRowIndex][$fieldKey]);
                             }
-                        } elseif(is_array($compiledFieldValue)) {
+                        } elseif (is_array($compiledFieldValue)) {
                             // there are multiple values
                             foreach ($compiledFieldValue as $compiledFieldSingleValue) {
                                 if (!is_array($compiledFieldSingleValue)) {
@@ -142,11 +142,10 @@ class ContentCompiledColumnTransformer
                                     'position' => $fieldKeyCounts[$fieldKey],
                                 ];
                             }
-                            if(self::$avoidDuplicates){
+                            if (self::$avoidDuplicates) {
                                 unset($contentRows[$contentRowIndex][$fieldKey]);
                             }
                         }
-
                     }
                 }
             }
@@ -161,25 +160,26 @@ class ContentCompiledColumnTransformer
         $fieldKeys = config('railcontent.compiled_column_mapping_field_keys', []);
         $subContentFieldKeys = config('railcontent.compiled_column_mapping_sub_content_field_keys', []);
 
-        foreach($contentRows as $contentRowIndex => $contentRow){
+        foreach ($contentRows as $contentRowIndex => $contentRow) {
             $lessons = $contentRow['lessons_grouped_by_field'] ?? [];
             $lessonContentIds = explode(',', $lessons);
             $lessonContentIds = array_unique($lessonContentIds);
             $allLessonsCount = count($lessonContentIds);
-            $lessonContentIds = (array_slice($lessonContentIds,0,10));
+            $lessonContentIds = (array_slice($lessonContentIds, 0, 10));
             $contentRows[$contentRowIndex]['all_lessons_count'] = $contentRow['lessonsCount'] ?? $allLessonsCount;
-
 
             if (empty($lessonContentIds)) {
                 continue;
             }
 
-            if($contentRow['type'] == 'style' || $contentRow['type'] == 'artist') {
+            if ($contentRow['type'] == 'style' || $contentRow['type'] == 'artist') {
                 $contentRows[$contentRowIndex]['data'][] = [
                     'id' => substr(md5(mt_rand()), 0, 10),
                     'content_id' => substr(md5(mt_rand()), 0, 10),
                     'key' => 'head_shot_picture_url',
-                    'value' => 'https://dpwjbsxqtam5n.cloudfront.net/shows/challenges.jpg',
+                    'value' => ($contentRow['type'] == 'style') ?
+                        config('railcontent.default_avatar_style')[config('railcontent.brand', 'drumeo')] :
+                        config('railcontent.default_avatar_artist')[config('railcontent.brand', 'drumeo')],
                     'type' => 'string',
                     'position' => 1,
                 ];
@@ -198,15 +198,13 @@ class ContentCompiledColumnTransformer
                 $contentRowCompiledColumnValue = json_decode($data['compiled_view_data'] ?? '', true);
                 if (isset($data['compiled_view_data'])) {
                     foreach (
-                        $contentRowCompiledColumnValue as $compiledDataKey =>
-                        $compiledDataValue
+                        $contentRowCompiledColumnValue as $compiledDataKey => $compiledDataValue
                     ) {
                         if (in_array(
                             $compiledDataKey,
                             config('railcontent.content_fields_that_are_now_columns_in_the_content_table')
                         )) {
-                            $contentRows[$contentRowIndex]['lessons'][$index][$compiledDataKey] =
-                                $compiledDataValue;
+                            $contentRows[$contentRowIndex]['lessons'][$index][$compiledDataKey] = $compiledDataValue;
                         }
 
                         if (in_array($compiledDataKey, $dataKeys)) {
@@ -222,57 +220,57 @@ class ContentCompiledColumnTransformer
                             }
                         }
 
-                        if (in_array($compiledDataKey, $fieldKeys) && !in_array($compiledDataKey, $subContentFieldKeys)) {
-                                    $compiledFieldValue = Arr::wrap($compiledDataValue);
-                                    foreach ($compiledFieldValue as $compiledFieldSingleValue) {
-                                        $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
-                                            'id' => substr(md5(mt_rand()), 0, 10),
-                                            'content_id' => $contentRowCompiledColumnValue['id'],
-                                            'key' => $compiledDataKey,
-                                            'value' => $compiledFieldSingleValue,
-                                            'type' => 'string',
-                                            'position' => 1,
-                                        ];
+                        if (in_array($compiledDataKey, $fieldKeys) &&
+                            !in_array($compiledDataKey, $subContentFieldKeys)) {
+                            $compiledFieldValue = Arr::wrap($compiledDataValue);
+                            foreach ($compiledFieldValue as $compiledFieldSingleValue) {
+                                $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
+                                    'id' => substr(md5(mt_rand()), 0, 10),
+                                    'content_id' => $contentRowCompiledColumnValue['id'],
+                                    'key' => $compiledDataKey,
+                                    'value' => $compiledFieldSingleValue,
+                                    'type' => 'string',
+                                    'position' => 1,
+                                ];
+                            }
+                        } elseif (in_array($compiledDataKey, $fieldKeys) &&
+                            in_array($compiledDataKey, $subContentFieldKeys)) {
+                            if (isset($compiledDataValue['id'])) {
+                                $contentEntity = new ContentEntity();
+                                $contentEntity->replace($this->transform([$compiledDataValue])[0]);
+
+                                $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
+                                    'id' => substr(md5(mt_rand()), 0, 10),
+                                    'content_id' => $contentRowCompiledColumnValue['id'],
+                                    'key' => $compiledDataKey,
+                                    'value' => $contentEntity,
+                                    'type' => 'content',
+                                    'position' => 1,
+                                ];
+                            } elseif (is_array($compiledDataValue)) {
+                                // there are multiple values
+                                foreach ($compiledDataValue as $compiledFieldSingleValue) {
+                                    if (!is_array($compiledFieldSingleValue)) {
+                                        continue;
                                     }
-                                } elseif (in_array($compiledDataKey, $fieldKeys) && in_array($compiledDataKey, $subContentFieldKeys)) {
-                                    if (isset($compiledDataValue['id'])) {
-                                        $contentEntity = new ContentEntity();
-                                        $contentEntity->replace($this->transform([$compiledDataValue])[0]);
 
-                                        $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
-                                            'id' => substr(md5(mt_rand()), 0, 10),
-                                            'content_id' => $contentRowCompiledColumnValue['id'],
-                                            'key' => $compiledDataKey,
-                                            'value' => $contentEntity,
-                                            'type' => 'content',
-                                            'position' => 1,
-                                        ];
+                                    $contentEntity = new ContentEntity();
+                                    $contentEntity->replace($this->transform([$compiledFieldSingleValue])[0]);
 
-                                    } elseif (is_array($compiledDataValue)) {
-                                        // there are multiple values
-                                        foreach ($compiledDataValue as $compiledFieldSingleValue) {
-                                            if (!is_array($compiledFieldSingleValue)) {
-                                                continue;
-                                            }
-
-                                            $contentEntity = new ContentEntity();
-                                            $contentEntity->replace($this->transform([$compiledFieldSingleValue])[0]);
-
-                                            $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
-                                                'id' => substr(md5(mt_rand()), 0, 10),
-                                                'content_id' => $contentRowCompiledColumnValue['id'],
-                                                'key' => $compiledDataKey,
-                                                'value' => $contentEntity,
-                                                'type' => 'content',
-                                                'position' => 1,
-                                            ];
-                                        }
-                                    }
+                                    $contentRows[$contentRowIndex]['lessons'][$index]['fields'][] = [
+                                        'id' => substr(md5(mt_rand()), 0, 10),
+                                        'content_id' => $contentRowCompiledColumnValue['id'],
+                                        'key' => $compiledDataKey,
+                                        'value' => $contentEntity,
+                                        'type' => 'content',
+                                        'position' => 1,
+                                    ];
                                 }
+                            }
+                        }
                     }
                 }
             }
-
         }
 
         return $contentRows;

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -174,6 +174,24 @@ class ContentCompiledColumnTransformer
                 continue;
             }
 
+            if($contentRow['type'] == 'style'){
+                $contentRows[$contentRowIndex]['data'][] = [
+                    'id' => substr(md5(mt_rand()), 0, 10),
+                    'content_id' =>substr(md5(mt_rand()), 0, 10),
+                    'key' => 'head_shot_picture_url',
+                    'value' => 'https://dpwjbsxqtam5n.cloudfront.net/shows/challenges.jpg',
+                    'type' => 'string',
+                    'position' => 1,
+                ];
+                $contentRows[$contentRowIndex]['fields'][] = [
+                    'id' => substr(md5(mt_rand()), 0, 10),
+                    'content_id' =>substr(md5(mt_rand()), 0, 10),
+                    'key' => 'name',
+                    'value' => $contentRow['grouped_by_field'],
+                    'type' => 'string',
+                    'position' => 1,
+                ];
+            }
             // data
             $dataKeyCounts = [];
 
@@ -302,7 +320,8 @@ class ContentCompiledColumnTransformer
                 }
             }
             $content = collect($contentRows[$contentRowIndex]);
-            $contentRows[$contentRowIndex] = $content->only(['data','id','slug','type','fields','url','published_on','brand','lessons','all_lessons_count','web_url_path']);
+
+            $contentRows[$contentRowIndex] = $content->only(['grouped_by_field','data','id','slug','type','fields','url','published_on','brand','lessons','all_lessons_count','web_url_path']);
         }
         return $contentRows;
     }

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -178,7 +178,7 @@ class ContentCompiledColumnTransformer
                     'content_id' => substr(md5(mt_rand()), 0, 10),
                     'key' => 'head_shot_picture_url',
                     'value' => ($contentRow['type'] == 'style') ?
-                        config('railcontent.default_avatar_style')[config('railcontent.brand', 'drumeo')] :
+                        (config('railcontent.avatar_style')[$contentRow['grouped_by_field']] ?? config('railcontent.default_avatar_style')[config('railcontent.brand', 'drumeo')]) :
                         config('railcontent.default_avatar_artist')[config('railcontent.brand', 'drumeo')],
                     'type' => 'string',
                     'position' => 1,

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -209,7 +209,7 @@ class ContentCompiledColumnTransformer
                                         'content_id' => $contentRowCompiledColumnValue['id'],
                                         'key' => $dataKey,
                                         'value' => $compiledDataSingleValue,
-                                        'position' => $dataKeyCounts[$dataKey],
+                                        'position' => 1,
                                     ];
                                 }
                             }
@@ -246,7 +246,7 @@ class ContentCompiledColumnTransformer
                                         'key' => $fieldKey,
                                         'value' => $compiledFieldSingleValue,
                                         'type' => 'string',
-                                        'position' => $fieldKeyCounts[$fieldKey],
+                                        'position' => 1,
                                     ];
                                     if (self::$avoidDuplicates) {
                                         unset($contentRows[$contentRowIndex][$fieldKey]);
@@ -266,7 +266,7 @@ class ContentCompiledColumnTransformer
                                         'key' => $fieldKey,
                                         'value' => $contentEntity,
                                         'type' => 'content',
-                                        'position' => $fieldKeyCounts[$fieldKey],
+                                        'position' => 1,
                                     ];
                                     if (self::$avoidDuplicates) {
                                         unset($contentRows[$contentRowIndex][$fieldKey]);
@@ -289,7 +289,7 @@ class ContentCompiledColumnTransformer
                                             'key' => $fieldKey,
                                             'value' => $contentEntity,
                                             'type' => 'content',
-                                            'position' => $fieldKeyCounts[$fieldKey],
+                                            'position' => 1,
                                         ];
                                     }
                                     if (self::$avoidDuplicates) {

--- a/src/Transformers/ContentCompiledColumnTransformer.php
+++ b/src/Transformers/ContentCompiledColumnTransformer.php
@@ -163,7 +163,7 @@ class ContentCompiledColumnTransformer
 
         foreach($contentRows as $contentRowIndex => $contentRow){
             $lessons = $contentRow['lessons_grouped_by_field'] ?? [];
-            $lessonContentIds = json_decode($lessons ?? '', true);
+            $lessonContentIds = explode(',', $lessons);
             $lessonContentIds = array_unique($lessonContentIds);
             $allLessonsCount = count($lessonContentIds);
             $lessonContentIds = (array_slice($lessonContentIds,0,5));


### PR DESCRIPTION
Filters v2 System
- available only when 'count_filter_items' parameter is set on the request
- group contents by fields(genre/style, artists, instructors)
- mapping system for filter options as difficulty, bpm, instrument-less, content type
- different search when we have group contents by fields 
- new content fields tables for filter system: essentials, theory, creativity, lifestyle, gear
- filter for all lessons should limit results to max 100 lessons
- count items for each filter option