### PR TITLE
Hotfix fsu 158

### DIFF
--- a/src/Entities/ContentFilterResultsEntity.php
+++ b/src/Entities/ContentFilterResultsEntity.php
@@ -14,15 +14,12 @@ class ContentFilterResultsEntity extends Entity
     public function toResponseRawJson()
     {
         return reply()
-            ->json(
-                $this->results(),
-                [
-                    'transformer' => DataTransformer::class,
-                    'totalResults' => $this->totalResults(),
-                    'totalLessons' => $this->totalLessons(),
-                    'filterOptions' => $this->filterOptions(),
-                ]
-            )
+            ->json($this->results(), [
+                                       'transformer' => DataTransformer::class,
+                                       'totalResults' => $this->totalResults(),
+                                       'totalLessons' => $this->totalLessons(),
+                                       'filterOptions' => $this->filterOptions(),
+                                   ])
             ->getContent();
     }
 
@@ -31,15 +28,12 @@ class ContentFilterResultsEntity extends Entity
      */
     public function toJsonResponse()
     {
-        return reply()->json(
-            $this->results(),
-            [
-                'transformer' => DataTransformer::class,
-                'totalResults' => $this->totalResults(),
-                'totalLessons' => $this->totalLessons(),
-                'filterOptions' => $this->filterOptions(),
-            ]
-        );
+        return reply()->json($this->results(), [
+                                                 'transformer' => DataTransformer::class,
+                                                 'totalResults' => $this->totalResults(),
+                                                 'totalLessons' => $this->totalLessons(),
+                                                 'filterOptions' => $this->filterOptions(),
+                                             ]);
     }
 
     /**

--- a/src/Entities/ContentFilterResultsEntity.php
+++ b/src/Entities/ContentFilterResultsEntity.php
@@ -19,6 +19,7 @@ class ContentFilterResultsEntity extends Entity
                 [
                     'transformer' => DataTransformer::class,
                     'totalResults' => $this->totalResults(),
+                    'totalLessons' => $this->totalLessons(),
                     'filterOptions' => $this->filterOptions(),
                 ]
             )
@@ -35,6 +36,7 @@ class ContentFilterResultsEntity extends Entity
             [
                 'transformer' => DataTransformer::class,
                 'totalResults' => $this->totalResults(),
+                'totalLessons' => $this->totalLessons(),
                 'filterOptions' => $this->filterOptions(),
             ]
         );
@@ -62,5 +64,13 @@ class ContentFilterResultsEntity extends Entity
     public function filterOptions()
     {
         return $this['filter_options'] ?? [];
+    }
+
+    /**
+     * @return int
+     */
+    public function totalLessons()
+    {
+        return $this['total_lessons'] ?? 0;
     }
 }

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -1527,11 +1527,12 @@ class ContentRepository extends RepositoryBase
     }
 
     /**
+     * @param false $groupBy
      * @return int
      */
-    public function countFilter()
+    public function countFilter($groupBy = false)
     {
-        if ($this->groupByFields) {
+        if ($groupBy) {
             $subQuery =
                 $this->query()
                     ->restrictByTypes($this->typesToInclude)
@@ -1576,10 +1577,6 @@ class ContentRepository extends RepositoryBase
                 ->addBinding($subQuery->getBindings())
                 ->count();
 
-        //        //All lessons page should display max 100 lessons
-        //        if(count($this->typesToInclude) > 10 && $count > 100){
-        //            return 100;
-        //        }
         return $count;
     }
 

--- a/src/Repositories/ContentRepository.php
+++ b/src/Repositories/ContentRepository.php
@@ -598,10 +598,13 @@ class ContentRepository extends RepositoryBase
                     '=',
                     ConfigService::$tableContent.'.id'
                 )
-                ->havingRaw(ConfigService::$tableContent.".type IN (".implode(
-                                ",",
-                                array_fill(0, count([$type]), "?")
-                            ).")", [$type])
+                ->havingRaw(
+                    ConfigService::$tableContent.".type IN (".implode(
+                        ",",
+                        array_fill(0, count([$type]), "?")
+                    ).")",
+                    [$type]
+                )
                 ->where(ConfigService::$tableUserContentProgress.'.user_id', $userId)
                 ->where(ConfigService::$tableUserContentProgress.'.state', $state)
                 ->orderBy('published_on', 'desc')
@@ -1059,7 +1062,8 @@ class ContentRepository extends RepositoryBase
                 ->selectPrimaryColumns()
                 ->selectInheritenceColumns()
                 ->restrictByUserAccess()
-                ->leftJoin(ConfigService::$tableContentHierarchy,
+                ->leftJoin(
+                    ConfigService::$tableContentHierarchy,
                     function (JoinClause $joinClause) use ($childContentIds) {
                         $joinClause->on(
                             ConfigService::$tableContentHierarchy.'.parent_id',
@@ -1067,7 +1071,8 @@ class ContentRepository extends RepositoryBase
                             ConfigService::$tableContent.'.id'
                         )
                             ->whereIn(ConfigService::$tableContentHierarchy.'.child_id', $childContentIds);
-                    })
+                    }
+                )
                 ->where(ConfigService::$tableContent.'.user_id', $userId);
 
         if (!empty($slug)) {
@@ -2631,8 +2636,7 @@ class ContentRepository extends RepositoryBase
             }
 
             $joinTablesQuery->addSelect(
-                [$filterOptionTableAliasName.'.'.$filterOptionColumnName.' as '.$filterOptionColumnName]
-            );
+                [$filterOptionTableAliasName.'.'.$filterOptionColumnName.' as '.$filterOptionColumnName]);
 
             $groupBy[] = $filterOptionColumnName;
 

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1050,12 +1050,17 @@ class ContentService
                 $filter->groupByField($groupBy);
             }
 
+            /**
+             * total_results = number of items(lessons or group) used for pagination
+             * total_lessons = number of items(lessons);
+             *      if we have results grouped, it will sum up the total number of lessons in each group;
+             *      if we do not have results grouped it is equal to total_results
+             */
             $resultsDB = new ContentFilterResultsEntity([
                 'results' => $filter->retrieveFilter(),
-                'total_results' => $pullPagination ?
-                    $filter->countFilter() : 0,
-                'filter_options' => $pullFilterFields ? $this->getFilterOptions($filter, $includedTypes) : [],
-                                                            ]);
+                'total_results' => $pullPagination ? $filter->countFilter($groupBy) : 0,
+                'total_lessons' => $pullPagination ? $filter->countFilter() : 0,
+                'filter_options' => $pullFilterFields ? $this->getFilterOptions($filter, $includedTypes) : []]);
 
             $results = CacheHelper::saveUserCache($hash, $resultsDB, Arr::pluck($resultsDB['results'], 'id'));
             $results = new ContentFilterResultsEntity($results);

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -1067,12 +1067,13 @@ class ContentService
              *      if we have results grouped, it will sum up the total number of lessons in each group;
              *      if we do not have results grouped it is equal to total_results
              */
+            $totalLessons = $pullPagination ? $filter->countFilter() : 0;
+            $totalResults = ($groupBy && $pullPagination) ? $filter->countFilter($groupBy) : $totalLessons;
+
             $resultsDB = new ContentFilterResultsEntity([
                                                             'results' => $filter->retrieveFilter(),
-                                                            'total_results' => $pullPagination ?
-                                                                $filter->countFilter($groupBy) : 0,
-                                                            'total_lessons' => $pullPagination ?
-                                                                $filter->countFilter() : 0,
+                                                            'total_results' => $totalResults,
+                                                            'total_lessons' => $totalLessons,
                                                             'filter_options' => $pullFilterFields ?
                                                                 $this->getFilterOptions($filter, $includedTypes) : [],
                                                         ]);
@@ -2169,26 +2170,34 @@ class ContentService
                                 ->toDateTimeString()
                         );
                 })
-                ->leftJoin('railcontent_user_content_progress AS ucp_1',
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_1',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_1.content_id', '=', 'ch_1.child_id')
                             ->where('ucp_1.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_2',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_2',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_2.content_id', '=', 'ch_2.child_id')
                             ->where('ucp_2.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_3',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_3',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_3.content_id', '=', 'ch_3.child_id')
                             ->where('ucp_3.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_4',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_4',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_4.content_id', '=', 'ch_4.child_id')
                             ->where('ucp_4.user_id', $userId);
-                    })
+                    }
+                )
                 ->select([
                              'ch_1.parent_id AS ch_1_parent_id',
                              'ch_2.parent_id AS ch_2_parent_id',
@@ -2551,16 +2560,14 @@ class ContentService
             $limit,
             $page
         );
-        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn(
-            $types,
+        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn($types,
             [ContentService::STATUS_SCHEDULED, ContentService::STATUS_PUBLISHED],
             Carbon::now()
-                ->toDateTimeString(),
+                                                                                            ->toDateTimeString(),
             '>',
             'published_on',
             'asc',
-            []
-        );
+            []);
 
         ContentRepository::$availableContentStatues = $oldStatuses;
         ContentRepository::$pullFutureContent = $oldFutureContent;
@@ -2610,16 +2617,14 @@ class ContentService
             ),
             'content'
         );
-        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn(
-            $types,
+        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn($types,
             [ContentService::STATUS_SCHEDULED],
             Carbon::now()
-                ->toDateTimeString(),
+                                                                                            ->toDateTimeString(),
             '>',
             'published_on',
             'asc',
-            []
-        );
+            []);
 
         return new ContentFilterResultsEntity([
                                                   'results' => $scheduleEvents,
@@ -2666,26 +2671,34 @@ class ContentService
                     return $joinClause->on('ch_4_child.id', '=', 'ch_4.child_id')
                         ->whereNot('ch_4_child.type', 'assignment');
                 })
-                ->leftJoin('railcontent_user_content_progress AS ucp_1',
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_1',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_1.content_id', '=', 'ch_1.child_id')
                             ->where('ucp_1.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_2',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_2',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_2.content_id', '=', 'ch_2.child_id')
                             ->where('ucp_2.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_3',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_3',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_3.content_id', '=', 'ch_3.child_id')
                             ->where('ucp_3.user_id', $userId);
-                    })
-                ->leftJoin('railcontent_user_content_progress AS ucp_4',
+                    }
+                )
+                ->leftJoin(
+                    'railcontent_user_content_progress AS ucp_4',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_4.content_id', '=', 'ch_4.child_id')
                             ->where('ucp_4.user_id', $userId);
-                    })
+                    }
+                )
                 ->select([
                              'ch_1.parent_id AS ch_1_parent_id',
                              'ch_2.parent_id AS ch_2_parent_id',

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -233,8 +233,14 @@ class ContentService
      * @param int limit -
      * @return mixed|Collection|null
      */
-    public function getRecommendationsByContentType($user_id, $brand, $contentTypes, RecommenderSection $section, bool $randomize=false, $limit=6)
-    {
+    public function getRecommendationsByContentType(
+        $user_id,
+        $brand,
+        $contentTypes,
+        RecommenderSection $section,
+        bool $randomize = false,
+        $limit = 6
+    ) {
         $filter = $this->contentRepository->startFilter(
             1,
             $limit,
@@ -245,14 +251,17 @@ class ContentService
             [],
         );
         $filterOptions = $this->getFilterOptions($filter, true, $contentTypes);
-        $cacheKey = 'RECSYS-' . $user_id . '-' . $brand;
-        $cached = Cache::store('redis')->get($cacheKey);
-        if(!empty($cached)) {
+        $cacheKey = 'RECSYS-'.$user_id.'-'.$brand;
+        $cached =
+            Cache::store('redis')
+                ->get($cacheKey);
+        if (!empty($cached)) {
             $recommendations = $cached;
         } else {
             $recommendations = $this->recommendationService->getFilteredRecommendations($user_id, $brand, $section);
             $ttl = 60 * 60;
-            Cache::store('redis')->put($cacheKey, $recommendations, $ttl);
+            Cache::store('redis')
+                ->put($cacheKey, $recommendations, $ttl);
         }
 
         if ($randomize) {
@@ -261,14 +270,15 @@ class ContentService
             $recommendations = array_slice($recommendations, 0, $limit);
         }
         $content = $this->getByIds($recommendations);
+
         return (new ContentFilterResultsEntity([
-            'results' => $content,
-            'filter_options' => $filterOptions,
-            'total_results' => $filter->countFilter()
-        ]));
+                                                   'results' => $content,
+                                                   'filter_options' => $filterOptions,
+                                                   'total_results' => $filter->countFilter(),
+                                               ]));
     }
 
-    private function randomizeRecommendations($recommendations, $limit=6, $useHourly=true)
+    private function randomizeRecommendations($recommendations, $limit = 6, $useHourly = true)
     {
         if ($limit > count($recommendations)) {
             return $recommendations;
@@ -278,8 +288,9 @@ class ContentService
             // no caching involved :)
             $hour = date("H");
             srand($hour);
-            $randomKeys =  array_rand($recommendations, $limit);
+            $randomKeys = array_rand($recommendations, $limit);
             srand(time());
+
             return array_intersect_key($recommendations, array_flip($randomKeys));
         } else {
             return array_rand($recommendations, $limit);
@@ -1046,7 +1057,7 @@ class ContentService
                 );
             }
 
-            if($groupBy){
+            if ($groupBy) {
                 $filter->groupByField($groupBy);
             }
 
@@ -1057,16 +1068,21 @@ class ContentService
              *      if we do not have results grouped it is equal to total_results
              */
             $resultsDB = new ContentFilterResultsEntity([
-                'results' => $filter->retrieveFilter(),
-                'total_results' => $pullPagination ? $filter->countFilter($groupBy) : 0,
-                'total_lessons' => $pullPagination ? $filter->countFilter() : 0,
-                'filter_options' => $pullFilterFields ? $this->getFilterOptions($filter, $includedTypes) : []]);
+                                                            'results' => $filter->retrieveFilter(),
+                                                            'total_results' => $pullPagination ?
+                                                                $filter->countFilter($groupBy) : 0,
+                                                            'total_lessons' => $pullPagination ?
+                                                                $filter->countFilter() : 0,
+                                                            'filter_options' => $pullFilterFields ?
+                                                                $this->getFilterOptions($filter, $includedTypes) : [],
+                                                        ]);
 
             $results = CacheHelper::saveUserCache($hash, $resultsDB, Arr::pluck($resultsDB['results'], 'id'));
             $results = new ContentFilterResultsEntity($results);
         }
 
-        $decorator = ($groupBy) ? 'group':'content';
+        $decorator = ($groupBy) ? 'group' : 'content';
+
         return Decorator::decorate($results, $decorator);
     }
 
@@ -1077,7 +1093,8 @@ class ContentService
         if (!empty($filterFields['difficulty'])) {
             if (ContentRepository::$countFilterOptionItems == 1) {
                 $filterFields['difficulty'] = $this->filterOptionsMapping(
-                    $filterFields['difficulty'], 'railcontent.difficulty_map'
+                    $filterFields['difficulty'],
+                    'railcontent.difficulty_map'
                 );
             } else {
                 $filterFields['difficulty'] = $this->difficultyFilterOptionsCleanup(
@@ -1097,24 +1114,27 @@ class ContentService
 
         if (!empty($filterFields['type'])) {
             if (ContentRepository::$countFilterOptionItems == 1) {
-                $filterFields['type'] = array_map(function($m) { return ucwords(str_replace("-", " ", $m));}, $filterFields['type']);
+                $filterFields['type'] = array_map(function ($m) {
+                    return ucwords(str_replace("-", " ", $m));
+                }, $filterFields['type']);
             }
         }
 
         if (!empty($filterFields['instrumentless'])) {
             if (ContentRepository::$countFilterOptionItems == 1) {
                 $filterFields['instrumentless'] = $this->filterOptionsMapping(
-                    $filterFields['instrumentless'], 'railcontent.instrumentless_map.'.config('railcontent.brand')
+                    $filterFields['instrumentless'],
+                    'railcontent.instrumentless_map.'.config('railcontent.brand')
                 );
             }
         }
 
-        if(!ContentRepository::$countFilterOptionItems){
+        if (!ContentRepository::$countFilterOptionItems) {
             return $filterFields;
         }
         $order = ContentRepository::$catalogMetaAllowableFilters;
 
-        if($order) {
+        if ($order) {
             $filterFields = array_merge(array_fill_keys($order, 0), $filterFields);
         }
 
@@ -1190,19 +1210,19 @@ class ContentService
         }
 
         $id = $this->contentRepository->create([
-            'slug' => $slug,
-            'type' => $type,
-            'sort' => $sort,
-            'status' => $status ?? self::STATUS_DRAFT,
-            'language' => $language ?? ConfigService::$defaultLanguage,
-            'brand' => $brand ?? ConfigService::$brand,
-            //                                                   'instrumentless' => ($type === 'song') ? false : null,
-            'total_xp' => $this->getDefaultXP($type, 0),
-            'user_id' => $userId,
-            'published_on' => $publishedOn,
-            'created_on' => Carbon::now()
-                ->toDateTimeString(),
-        ]);
+                                                   'slug' => $slug,
+                                                   'type' => $type,
+                                                   'sort' => $sort,
+                                                   'status' => $status ?? self::STATUS_DRAFT,
+                                                   'language' => $language ?? ConfigService::$defaultLanguage,
+                                                   'brand' => $brand ?? ConfigService::$brand,
+                                                   //                                                   'instrumentless' => ($type === 'song') ? false : null,
+                                                   'total_xp' => $this->getDefaultXP($type, 0),
+                                                   'user_id' => $userId,
+                                                   'published_on' => $publishedOn,
+                                                   'created_on' => Carbon::now()
+                                                       ->toDateTimeString(),
+                                               ]);
 
         //save the link with parent if the parent id exist on the request
         if ($parentId) {
@@ -1974,31 +1994,31 @@ class ContentService
                     'rch4.parent_id'
                 )
                 ->select([
-                    'rch1.child_id as rch1_child_id',
-                    'rch1.parent_id as rch1_parent_id',
-                    'rch1.child_position as rch1_child_position',
-                    'rcp1.id as rcp1_content_id',
-                    'rcp1.slug as rcp1_content_slug',
-                    'rcp1.type as rcp1_content_type',
-                    'rch2.child_id as rch2_child_id',
-                    'rch2.parent_id as rch2_parent_id',
-                    'rch2.child_position as rch2_child_position',
-                    'rcp2.id as rcp2_content_id',
-                    'rcp2.slug as rcp2_content_slug',
-                    'rcp2.type as rcp2_content_type',
-                    'rch3.child_id as rch3_child_id',
-                    'rch3.parent_id as rch3_parent_id',
-                    'rch3.child_position as rch3_child_position',
-                    'rcp3.id as rcp3_content_id',
-                    'rcp3.slug as rcp3_content_slug',
-                    'rcp3.type as rcp3_content_type',
-                    'rch4.child_id as rch4_child_id',
-                    'rch4.parent_id as rch4_parent_id',
-                    'rch4.child_position as rch4_child_position',
-                    'rcp4.id as rcp4_content_id',
-                    'rcp4.slug as rcp4_content_slug',
-                    'rcp4.type as rcp4_content_type',
-                ])
+                             'rch1.child_id as rch1_child_id',
+                             'rch1.parent_id as rch1_parent_id',
+                             'rch1.child_position as rch1_child_position',
+                             'rcp1.id as rcp1_content_id',
+                             'rcp1.slug as rcp1_content_slug',
+                             'rcp1.type as rcp1_content_type',
+                             'rch2.child_id as rch2_child_id',
+                             'rch2.parent_id as rch2_parent_id',
+                             'rch2.child_position as rch2_child_position',
+                             'rcp2.id as rcp2_content_id',
+                             'rcp2.slug as rcp2_content_slug',
+                             'rcp2.type as rcp2_content_type',
+                             'rch3.child_id as rch3_child_id',
+                             'rch3.parent_id as rch3_parent_id',
+                             'rch3.child_position as rch3_child_position',
+                             'rcp3.id as rcp3_content_id',
+                             'rcp3.slug as rcp3_content_slug',
+                             'rcp3.type as rcp3_content_type',
+                             'rch4.child_id as rch4_child_id',
+                             'rch4.parent_id as rch4_parent_id',
+                             'rch4.child_position as rch4_child_position',
+                             'rcp4.id as rcp4_content_id',
+                             'rcp4.slug as rcp4_content_slug',
+                             'rcp4.type as rcp4_content_type',
+                         ])
                 ->whereIn('rch1.child_id', $contentIds)
                 ->get();
 
@@ -2094,12 +2114,14 @@ class ContentService
     public function getNextContentForParentContentForUser($parentContentId, $userId)
     {
         $isParentComplete =
-            $this->contentRepository->connectionMask()->table('railcontent_user_content_progress')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_user_content_progress')
                 ->where(['content_id' => $parentContentId, 'user_id' => $userId, 'state' => 'complete'])
                 ->exists();
 
         $contentHierarchyDataQuery =
-            $this->contentRepository->connectionMask()->table('railcontent_content_hierarchy AS ch_1')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_content_hierarchy AS ch_1')
                 ->leftJoin('railcontent_content_hierarchy AS ch_2', 'ch_2.parent_id', '=', 'ch_1.child_id')
                 ->leftJoin('railcontent_content_hierarchy AS ch_3', 'ch_3.parent_id', '=', 'ch_2.child_id')
                 ->leftJoin('railcontent_content_hierarchy AS ch_4', 'ch_4.parent_id', '=', 'ch_3.child_id')
@@ -2147,56 +2169,48 @@ class ContentService
                                 ->toDateTimeString()
                         );
                 })
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_1',
+                ->leftJoin('railcontent_user_content_progress AS ucp_1',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_1.content_id', '=', 'ch_1.child_id')
                             ->where('ucp_1.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_2',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_2',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_2.content_id', '=', 'ch_2.child_id')
                             ->where('ucp_2.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_3',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_3',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_3.content_id', '=', 'ch_3.child_id')
                             ->where('ucp_3.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_4',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_4',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_4.content_id', '=', 'ch_4.child_id')
                             ->where('ucp_4.user_id', $userId);
-                    }
-                )
+                    })
                 ->select([
-                    'ch_1.parent_id AS ch_1_parent_id',
-                    'ch_2.parent_id AS ch_2_parent_id',
-                    'ch_3.parent_id AS ch_3_parent_id',
-                    'ch_4.parent_id AS ch_4_parent_id',
-                    'ch_1.child_id AS ch_1_child_id',
-                    'ch_2.child_id AS ch_2_child_id',
-                    'ch_3.child_id AS ch_3_child_id',
-                    'ch_4.child_id AS ch_4_child_id',
-                    'ch_1.child_position AS ch_1_child_position',
-                    'ch_2.child_position AS ch_2_child_position',
-                    'ch_3.child_position AS ch_3_child_position',
-                    'ch_4.child_position AS ch_4_child_position',
-                    'ch_1_child.slug AS ch_1_child_slug',
-                    'ch_2_child.slug AS ch_2_child_slug',
-                    'ch_3_child.slug AS ch_3_child_slug',
-                    'ch_4_child.slug AS ch_4_child_slug',
-                    'ucp_1.state AS ucp_1_state',
-                    'ucp_2.state AS ucp_2_state',
-                    'ucp_3.state AS ucp_3_state',
-                    'ucp_4.state AS ucp_4_state',
-                ])
+                             'ch_1.parent_id AS ch_1_parent_id',
+                             'ch_2.parent_id AS ch_2_parent_id',
+                             'ch_3.parent_id AS ch_3_parent_id',
+                             'ch_4.parent_id AS ch_4_parent_id',
+                             'ch_1.child_id AS ch_1_child_id',
+                             'ch_2.child_id AS ch_2_child_id',
+                             'ch_3.child_id AS ch_3_child_id',
+                             'ch_4.child_id AS ch_4_child_id',
+                             'ch_1.child_position AS ch_1_child_position',
+                             'ch_2.child_position AS ch_2_child_position',
+                             'ch_3.child_position AS ch_3_child_position',
+                             'ch_4.child_position AS ch_4_child_position',
+                             'ch_1_child.slug AS ch_1_child_slug',
+                             'ch_2_child.slug AS ch_2_child_slug',
+                             'ch_3_child.slug AS ch_3_child_slug',
+                             'ch_4_child.slug AS ch_4_child_slug',
+                             'ucp_1.state AS ucp_1_state',
+                             'ucp_2.state AS ucp_2_state',
+                             'ucp_3.state AS ucp_3_state',
+                             'ucp_4.state AS ucp_4_state',
+                         ])
                 ->where('ch_1.parent_id', $parentContentId)
                 ->orderBy('ch_1.child_position')
                 ->orderBy('ch_2.child_position')
@@ -2262,21 +2276,24 @@ class ContentService
          * coach_focus_text
          */
         $contentRowsById =
-            $this->contentRepository->connectionMask()->table('railcontent_content')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_content')
                 ->whereIn('id', $contentIds)
                 ->get()
                 ->keyBy('id');
 
         // content fields are the source of truth at the moment but that will change eventually
         $contentsFieldRows =
-            $this->contentRepository->connectionMask()->table('railcontent_content_fields')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_content_fields')
                 ->whereIn('content_id', $contentIds)
                 ->get();
 
         $contentsFieldRowsByContentId = $contentsFieldRows->groupBy('content_id');
 
         $contentsDataRowsByContentId =
-            $this->contentRepository->connectionMask()->table('railcontent_content_data')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_content_data')
                 ->whereIn('content_id', $contentIds)
                 ->get()
                 ->groupBy('content_id');
@@ -2293,19 +2310,22 @@ class ContentService
 
         if (!empty($linkedContentIds)) {
             $contentsFieldLinkedContentRowsById =
-                $this->contentRepository->connectionMask()->table('railcontent_content')
+                $this->contentRepository->connectionMask()
+                    ->table('railcontent_content')
                     ->whereIn('id', $linkedContentIds)
                     ->get()
                     ->keyBy('id');
 
             $contentsFieldLinkedContentsFieldRowsById =
-                $this->contentRepository->connectionMask()->table('railcontent_content_fields')
+                $this->contentRepository->connectionMask()
+                    ->table('railcontent_content_fields')
                     ->whereIn('content_id', $linkedContentIds)
                     ->get()
                     ->groupBy('content_id');
 
             $contentsFieldLinkedContentsDataRowsById =
-                $this->contentRepository->connectionMask()->table('railcontent_content_data')
+                $this->contentRepository->connectionMask()
+                    ->table('railcontent_content_data')
                     ->whereIn('content_id', $linkedContentIds)
                     ->get()
                     ->groupBy('content_id');
@@ -2531,22 +2551,24 @@ class ContentService
             $limit,
             $page
         );
-        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn($types,
+        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn(
+            $types,
             [ContentService::STATUS_SCHEDULED, ContentService::STATUS_PUBLISHED],
             Carbon::now()
                 ->toDateTimeString(),
             '>',
             'published_on',
             'asc',
-            []);
+            []
+        );
 
         ContentRepository::$availableContentStatues = $oldStatuses;
         ContentRepository::$pullFutureContent = $oldFutureContent;
 
         $results = new ContentFilterResultsEntity([
-            'results' => $scheduleEvents,
-            'total_results' => $countEvents,
-        ]);
+                                                      'results' => $scheduleEvents,
+                                                      'total_results' => $countEvents,
+                                                  ]);
 
         return Decorator::decorate($results, 'content');
     }
@@ -2588,19 +2610,21 @@ class ContentService
             ),
             'content'
         );
-        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn($types,
+        $countEvents = $this->contentRepository->countByTypeInAndStatusInAndPublishedOn(
+            $types,
             [ContentService::STATUS_SCHEDULED],
             Carbon::now()
                 ->toDateTimeString(),
             '>',
             'published_on',
             'asc',
-            []);
+            []
+        );
 
         return new ContentFilterResultsEntity([
-            'results' => $scheduleEvents,
-            'total_results' => $countEvents,
-        ]);
+                                                  'results' => $scheduleEvents,
+                                                  'total_results' => $countEvents,
+                                              ]);
     }
 
     /**
@@ -2615,12 +2639,14 @@ class ContentService
     public function getNextCohortLesson($parentContentId, $userId)
     {
         $isParentComplete =
-            $this->contentRepository->connectionMask()->table('railcontent_user_content_progress')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_user_content_progress')
                 ->where(['content_id' => $parentContentId, 'user_id' => $userId, 'state' => 'completed'])
                 ->exists();
 
         $contentHierarchyDataQuery =
-            $this->contentRepository->connectionMask()->table('railcontent_content_hierarchy AS ch_1')
+            $this->contentRepository->connectionMask()
+                ->table('railcontent_content_hierarchy AS ch_1')
                 ->leftJoin('railcontent_content_hierarchy AS ch_2', 'ch_2.parent_id', '=', 'ch_1.child_id')
                 ->leftJoin('railcontent_content_hierarchy AS ch_3', 'ch_3.parent_id', '=', 'ch_2.child_id')
                 ->leftJoin('railcontent_content_hierarchy AS ch_4', 'ch_4.parent_id', '=', 'ch_3.child_id')
@@ -2640,56 +2666,48 @@ class ContentService
                     return $joinClause->on('ch_4_child.id', '=', 'ch_4.child_id')
                         ->whereNot('ch_4_child.type', 'assignment');
                 })
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_1',
+                ->leftJoin('railcontent_user_content_progress AS ucp_1',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_1.content_id', '=', 'ch_1.child_id')
                             ->where('ucp_1.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_2',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_2',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_2.content_id', '=', 'ch_2.child_id')
                             ->where('ucp_2.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_3',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_3',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_3.content_id', '=', 'ch_3.child_id')
                             ->where('ucp_3.user_id', $userId);
-                    }
-                )
-                ->leftJoin(
-                    'railcontent_user_content_progress AS ucp_4',
+                    })
+                ->leftJoin('railcontent_user_content_progress AS ucp_4',
                     function (JoinClause $joinClause) use ($userId) {
                         return $joinClause->on('ucp_4.content_id', '=', 'ch_4.child_id')
                             ->where('ucp_4.user_id', $userId);
-                    }
-                )
+                    })
                 ->select([
-                    'ch_1.parent_id AS ch_1_parent_id',
-                    'ch_2.parent_id AS ch_2_parent_id',
-                    'ch_3.parent_id AS ch_3_parent_id',
-                    'ch_4.parent_id AS ch_4_parent_id',
-                    'ch_1.child_id AS ch_1_child_id',
-                    'ch_2.child_id AS ch_2_child_id',
-                    'ch_3.child_id AS ch_3_child_id',
-                    'ch_4.child_id AS ch_4_child_id',
-                    'ch_1.child_position AS ch_1_child_position',
-                    'ch_2.child_position AS ch_2_child_position',
-                    'ch_3.child_position AS ch_3_child_position',
-                    'ch_4.child_position AS ch_4_child_position',
-                    'ch_1_child.slug AS ch_1_child_slug',
-                    'ch_2_child.slug AS ch_2_child_slug',
-                    'ch_3_child.slug AS ch_3_child_slug',
-                    'ch_4_child.slug AS ch_4_child_slug',
-                    'ucp_1.state AS ucp_1_state',
-                    'ucp_2.state AS ucp_2_state',
-                    'ucp_3.state AS ucp_3_state',
-                    'ucp_4.state AS ucp_4_state',
-                ])
+                             'ch_1.parent_id AS ch_1_parent_id',
+                             'ch_2.parent_id AS ch_2_parent_id',
+                             'ch_3.parent_id AS ch_3_parent_id',
+                             'ch_4.parent_id AS ch_4_parent_id',
+                             'ch_1.child_id AS ch_1_child_id',
+                             'ch_2.child_id AS ch_2_child_id',
+                             'ch_3.child_id AS ch_3_child_id',
+                             'ch_4.child_id AS ch_4_child_id',
+                             'ch_1.child_position AS ch_1_child_position',
+                             'ch_2.child_position AS ch_2_child_position',
+                             'ch_3.child_position AS ch_3_child_position',
+                             'ch_4.child_position AS ch_4_child_position',
+                             'ch_1_child.slug AS ch_1_child_slug',
+                             'ch_2_child.slug AS ch_2_child_slug',
+                             'ch_3_child.slug AS ch_3_child_slug',
+                             'ch_4_child.slug AS ch_4_child_slug',
+                             'ucp_1.state AS ucp_1_state',
+                             'ucp_2.state AS ucp_2_state',
+                             'ucp_3.state AS ucp_3_state',
+                             'ucp_4.state AS ucp_4_state',
+                         ])
                 ->where('ch_1.parent_id', $parentContentId)
                 ->orderBy('ch_1.child_position')
                 ->orderBy('ch_2.child_position')
@@ -2728,6 +2746,7 @@ class ContentService
             ContentRepository::$pullFutureContent = true;
             $content = $this->getById($contentId);
             ContentRepository::$pullFutureContent = $pullFutureContent;
+
             return $content;
         }
 
@@ -2774,7 +2793,7 @@ class ContentService
         } elseif (in_array(
                 $content['type'],
                 config('railcontent.content_multiple_level_content_depth_playlist_allowed', [])
-            ) || (in_array($content['brand'] ,['singeo', 'guitareo']) && $content['type'] == 'learning-path-level')) {
+            ) || (in_array($content['brand'], ['singeo', 'guitareo']) && $content['type'] == 'learning-path-level')) {
             ModeDecoratorBase::$decorationMode = ModeDecoratorBase::DECORATION_MODE_MINIMUM;
             $lessons = $this->getByParentId($content['id']);
             $soundsliceAssingment = 0;
@@ -2856,11 +2875,11 @@ class ContentService
                 $mappedDifficulty[$difficulty] = $difficultyNr;
             }
         }
-        $order = array('-','All','Introductory','Beginner', 'Intermediate', 'Advanced', 'Expert');
+        $order = ['-', 'All', 'Introductory', 'Beginner', 'Intermediate', 'Advanced', 'Expert'];
         $properOrderedArray = array_merge(array_fill_keys($order, 0), $mappedDifficulty);
         $filters['difficulty'] = [];
         foreach ($properOrderedArray as $difficulty => $count) {
-            if($count != 0 || array_key_exists($difficulty, $mappedDifficulty)) {
+            if ($count != 0 || array_key_exists($difficulty, $mappedDifficulty)) {
                 $filters['difficulty'][] = $difficulty.' ('.$count.')';
             }
         }
@@ -2871,11 +2890,12 @@ class ContentService
     /**
      * Mapping system for BPM filter options
      * Should take into consideration the mapping rules:
-    '50-90' => ['min' => 50, 'max' => 90],
-    '91-120' => ['min' => 91, 'max' => 120],
-    '121-150' => ['min' => 121, 'max' => 150],
-    '151-180' => ['min' => 151, 'max' => 180],
-    '181+' => ['min' => 181, 'max' => 10000],
+     * '50-90' => ['min' => 50, 'max' => 90],
+     * '91-120' => ['min' => 91, 'max' => 120],
+     * '121-150' => ['min' => 121, 'max' => 150],
+     * '151-180' => ['min' => 151, 'max' => 180],
+     * '181+' => ['min' => 181, 'max' => 10000],
+     *
      * @param $bpmOptions - is an array with the format: "bpm_value (number_or_lessons)"
      * @return array
      */
@@ -2887,18 +2907,17 @@ class ContentService
             $bpm = is_numeric($bpmArray[0]) ? (int)$bpmArray[0] : $bpmArray[0];
             $nr = str_replace(')', '', $bpmArray[1]);
             $mappingOptions = config('railcontent.bpm_map') ?? [];
-            foreach($mappingOptions as $key=>$mappingOption){
-                if($bpm >= $mappingOption['min'] && $bpm <= $mappingOption['max']){
-                    $mappedBpm[$key] =
-                        ($mappedBpm[$key] ?? 0) + $nr;
+            foreach ($mappingOptions as $key => $mappingOption) {
+                if ($bpm >= $mappingOption['min'] && $bpm <= $mappingOption['max']) {
+                    $mappedBpm[$key] = ($mappedBpm[$key] ?? 0) + $nr;
                 }
             }
         }
-        $order = array('50-90','91-120','121-150','151-180', '181+');
+        $order = ['50-90', '91-120', '121-150', '151-180', '181+'];
         $properOrderedArray = array_merge(array_fill_keys($order, 0), $mappedBpm);
         $filters['bpm'] = [];
         foreach ($properOrderedArray as $bpm => $count) {
-            if($count != 0 || array_key_exists($bpm, $mappedBpm)) {
+            if ($count != 0 || array_key_exists($bpm, $mappedBpm)) {
                 $filters['bpm'][] = $bpm.' ('.$count.')';
             }
         }


### PR DESCRIPTION
[FSU-158](https://musoraproduct.myjetbrains.com/youtrack/issue/FSU-158/MA-Filter-Results-button-when-filtering-collection-carousels
)

The button "Show # Results" from mobile app should always show the total number of lessons on all tabs. Now it show the number of groups if we are on Artist/Genre/Instructor tab

I added the total_lessons parameter to the filter content method. Now we have **total_results** = number of items(lessons or group) used for pagination on the web and  **total_lessons** = number of items(lessons);

-  if we have results grouped, **total_lessons** will sum up the total number of lessons in each group;
-  if we do not have results grouped **total_lessons**  is equal to  **total_results** 

Updates are deployed on beta-testing where you can test that the pagination is still working.
For the mobile app you can use the build https://app.bitrise.io/build/1347ee46-25db-4490-a07b-11dbeeb79424?tab=artifacts or
Postman endpoints: https://red-shadow-611407.postman.co/workspace/Team-Workspace~38bb093f-0978-4a83-8423-944a3c78fd51/request/9725390-dd5bbb86-c056-43d1-916f-12a7869d989a
