### PR TITLE
RecSys: Add and handle connection timeout for Huggingface

### DIFF
--- a/src/Services/RecommendationService.php
+++ b/src/Services/RecommendationService.php
@@ -2,6 +2,7 @@
 
 namespace Railroad\Railcontent\Services;
 
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Railroad\Railcontent\Enums\RecommenderSection;
@@ -96,15 +97,23 @@ class RecommendationService
     private function postToHuggingFaceWithRetry($data) {
         $url = config('railcontent.recsys.url');
         $authToken = config('railcontent.recsys.token');
-        $response = Http::withToken($authToken)->post($url, $data);
-        $status = $response->status();
-        if (in_array($status, $this->RETRY_ERROR_CODES)) {
-            $response = Http::withToken($authToken)->post($url, $data);
-        } else if ($status == 500) {
-            // attempt the backup URL
-            $backupURL = config('railcontent.recsys.backup_url');
-            $response = Http::withToken($authToken)->post($backupURL, $data);
+        $timeout = 12;
+        try {
+            $response = Http::withToken($authToken)->timeout($timeout)->post($url, $data);
             $status = $response->status();
+            if (in_array($status, $this->RETRY_ERROR_CODES)) {
+                $response = Http::withToken($authToken)->timeout($timeout)->post($url, $data);
+            } else {
+                if ($status == 500) {
+                    // attempt the backup URL
+                    $backupURL = config('railcontent.recsys.backup_url');
+                    $response = Http::withToken($authToken)->timeout($timeout)->post($backupURL, $data);
+                    $status = $response->status();
+                }
+            }
+        } catch (ConnectionException $ex) {
+            Log::warning("HuggingFace connection timed out after $timeout s");
+            return [];
         }
 
         $content = $response->json();


### PR DESCRIPTION
The default timeout for a connection is 30, if this occurs the webpage will show a service unavailable error to the user. We wanted to make that more user friendly.

These changes set a timeout of 12s and return an empty array if timedout. 
Iin testing it's taken up to 7s to process a result, specifically the first time the api is called after downtime. We'll monitor to see if this changes under load.

**Testing**
I was testing by changing the timeout to 1s and verifying the page loads in a reasonable way. We currently have no "no lessons found" page, this is just the backend.
As a note, the huggingface api caches results and can return in <1s, so I was sending a new user id by adding this before the first `post` call
```
            $data['user_ids'] = [631739];
            $timeout = 1;
```