### PR TITLE
Log Requests To Huggingface

### DIFF
--- a/src/Helpers/CacheHelper.php
+++ b/src/Helpers/CacheHelper.php
@@ -83,6 +83,22 @@ class CacheHelper
     }
 
     /**
+     * Generate a md5 key based on function arguments
+     *
+     * @return string
+     */
+    public static function getKeyFromArguments()
+    {
+        $args = func_get_args();
+        $key = '';
+        foreach ($args as $arg) {
+            $key .= implode(' ', array_values(Arr::wrap($arg)));
+        }
+        return md5($key);
+    }
+
+
+    /**
      * Insert all the specified value (content search key) at the tail of the set stored at key(content id).
      * If not exist a set for content id, it is created as empty set before performing the push operation.
      * e.g.: musora_railcontent_:content_contentId => "musora_railcontent_:userId_149628

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -140,7 +140,7 @@ class ContentService
         if(config('railcontent.recsys.use_caching') && !empty($cached) && array_filter($cached)) {
             $recommendations = $cached;
         } else {
-            Log::info('Retrieving recommendations from Huggingface for Key ' . $cacheKey);
+            Log::info('Retrieving recommendations from Huggingface for Key ' . $cacheKey .' :' . $user_id . '-' . $brand . '-' . $sectionString);
             $recommendations = $this->recommendationService->getFilteredRecommendations($user_id, $brand, $sections, $useFastImplementation);
             $ttl = 60 * 60 * 4;
             Cache::store('redis')

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Railroad\Railcontent\Decorators\Decorator;
 use Railroad\Railcontent\Decorators\ModeDecoratorBase;
 use Railroad\Railcontent\Entities\ContentEntity;
@@ -139,6 +140,7 @@ class ContentService
         if(config('railcontent.recsys.use_caching') && !empty($cached) && array_filter($cached)) {
             $recommendations = $cached;
         } else {
+            Log::info('Retrieving recommendations from Huggingface for Key ' . $cacheKey);
             $recommendations = $this->recommendationService->getFilteredRecommendations($user_id, $brand, $sections, $useFastImplementation);
             $ttl = 60 * 60 * 4;
             Cache::store('redis')

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -135,7 +135,7 @@ class ContentService
                 return $section->value;
             }, $sections)
         );
-        $cacheKey = 'RECSYS-' . CacheHelper::getKey($user_id, $brand, $sectionString);
+        $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($user_id, $brand, $sectionString);
         $cached = Cache::store('redis')->get($cacheKey);
         if(config('railcontent.recsys.use_caching') && !empty($cached) && array_filter($cached)) {
             $recommendations = $cached;


### PR DESCRIPTION
The cache was being duplicate between pages, as the userSettings are included in the cacheKey value.
I've added a new function in CacheHelper to NOT include userSettings this way it's deterministic >.<

The logging message is added so we can see how often the external values need to be retrieved.