### PR TITLE
RecSys - update caching logic to have a 2nd lock for concurrent requests

### DIFF
--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -51,7 +51,6 @@ class ContentService
 
 
     public $idContentCache = [];
-    private static LocalMutex $recSysMutex;
 
         /**
      * @param ContentRepository $contentRepository
@@ -83,7 +82,6 @@ class ContentService
         private ContentVideoRepository $contentVideoRepository,
         private RecommendationService $recommendationService,
     ) {
-        ContentService::$recSysMutex = new LocalMutex();
     }
 
     /**
@@ -113,15 +111,15 @@ class ContentService
 
 
     /**
-     * @param $userId -
-     * @param $brand -
+     * @param string|int $userId -
+     * @param string $brand -
      * @param array[RecommenderSection] $sections - sections to include in the result
-     * @param $pageSize -
-     * @param $page -
+     * @param int $pageSize -
+     * @param int $page -
      * @param array $groupByForLessonsPage - Which RecommenderSection to bundle in a groupby filter
      * @return ContentFilterResultsEntity -
      */
-    public function getRecommendedContent($userId, $brand, array $sections=[], $pageSize=6, $page=1, array $groupByForLessonsPage = [])
+    public function getRecommendedContent(string|int $userId, string $brand, array $sections=[], int $pageSize=6, int $page=1, array $groupByForLessonsPage = [])
     {
         $useFastImplementation = config('railcontent.recsys.use_fast_implementation');
         $useCaching = config('railcontent.recsys.use_caching');

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -4,7 +4,6 @@ namespace Railroad\Railcontent\Services;
 
 use App\Modules\Content\Models\ContentUserProgress;
 use Carbon\Carbon;
-use http\Exception\InvalidArgumentException;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
@@ -15,7 +14,6 @@ use Railroad\Railcontent\Decorators\Decorator;
 use Railroad\Railcontent\Decorators\ModeDecoratorBase;
 use Railroad\Railcontent\Entities\ContentEntity;
 use Railroad\Railcontent\Entities\ContentFilterResultsEntity;
-use Railroad\Railcontent\Enums\RecommenderSection;
 use Railroad\Railcontent\Events\ContentCreated;
 use Railroad\Railcontent\Events\ContentDeleted;
 use Railroad\Railcontent\Events\ContentSoftDeleted;
@@ -24,24 +22,18 @@ use Railroad\Railcontent\Events\ElasticDataShouldUpdate;
 use Railroad\Railcontent\Events\HierarchyUpdated;
 use Railroad\Railcontent\Helpers\CacheHelper;
 use Railroad\Railcontent\Helpers\ContentHelper;
-use Railroad\Railcontent\Repositories\CommentAssignmentRepository;
 use Railroad\Railcontent\Repositories\CommentRepository;
 use Railroad\Railcontent\Repositories\ContentBpmRepository;
 use Railroad\Railcontent\Repositories\ContentDatumRepository;
 use Railroad\Railcontent\Repositories\ContentFieldRepository;
-use Railroad\Railcontent\Repositories\ContentFollowsRepository;
 use Railroad\Railcontent\Repositories\ContentHierarchyRepository;
 use Railroad\Railcontent\Repositories\ContentInstructorRepository;
 use Railroad\Railcontent\Repositories\ContentPermissionRepository;
 use Railroad\Railcontent\Repositories\ContentRepository;
 use Railroad\Railcontent\Repositories\ContentStyleRepository;
 use Railroad\Railcontent\Repositories\ContentTopicRepository;
-use Railroad\Railcontent\Repositories\ContentVersionRepository;
 use Railroad\Railcontent\Repositories\ContentVideoRepository;
-use Railroad\Railcontent\Repositories\QueryBuilders\ElasticQueryBuilder;
-use Railroad\Railcontent\Repositories\RepositoryBase;
 use Railroad\Railcontent\Repositories\UserContentProgressRepository;
-use Railroad\Railcontent\Repositories\UserPermissionsRepository;
 use Railroad\Railcontent\Support\Collection;
 
 //use Railroad\Railcontent\Events\XPModified;
@@ -57,9 +49,11 @@ class ContentService
 
     const STATUS_DELETED = 'deleted';
 
-    public $idContentCache = [];
 
-    /**
+    public $idContentCache = [];
+    private static LocalMutex $recSysMutex;
+
+        /**
      * @param ContentRepository $contentRepository
      * @param ContentFieldRepository $fieldRepository
      * @param ContentDatumRepository $datumRepository
@@ -89,6 +83,7 @@ class ContentService
         private ContentVideoRepository $contentVideoRepository,
         private RecommendationService $recommendationService,
     ) {
+        ContentService::$recSysMutex = new LocalMutex();
     }
 
     /**
@@ -118,56 +113,83 @@ class ContentService
 
 
     /**
-     *
-     *
-     * @param int user_id
-     * @param string brand
-     * @param RecommenderSection[] sections
-     * @param int limit -
-     * @return mixed|Collection|null
+     * @param $userId -
+     * @param $brand -
+     * @param array[RecommenderSection] $sections - sections to include in the result
+     * @param $pageSize -
+     * @param $page -
+     * @param array $groupByForLessonsPage - Which RecommenderSection to bundle in a groupby filter
+     * @return ContentFilterResultsEntity -
      */
-    public function getRecommendedContent($user_id, $brand, array $sections=[], $pageSize=6, $page=1, array $groupByForLessonsPage = [])
+    public function getRecommendedContent($userId, $brand, array $sections=[], $pageSize=6, $page=1, array $groupByForLessonsPage = [])
     {
         $useFastImplementation = config('railcontent.recsys.use_fast_implementation');
+        $useCaching = config('railcontent.recsys.use_caching');
+
         $sectionString = !$useFastImplementation || count($sections) == 0 ? 'ALL' : implode(
             '-',
             array_map(function ($section) {
                 return $section->value;
             }, $sections)
         );
-        $ttl = 60 * 60 * 4;
-        $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($user_id, $brand, $sectionString);
-        $lockKey = 'RECSYS-LOCK' . CacheHelper::getKeyFromArguments($user_id, $brand, $sectionString);
-        // Logic here requires some explaination. Recommendation system calls each cost real $, so reducing extraneous calls is worth some messy logic.
-        // We cache recommendations contentids based on user,brand, and section. The external request can take up ta 10 seconds to return results.
-        // Concurrent (or close to concurrent) requests (such as during autoscrolling, will then call to the external service multiple times
-        // So we have a 2nd cache value (the lock) that indications an existing process has already started to retrieve results.
-        // If the original process returns (and fills the cache), we leave exit this loop.
-        // Otherwise we wait for the lock timeout of 15s, this shouldn't happen outside of exceptions in the pipeline,
-        // This will still be faster than making an external request.
-        // there is a small window at the end of the 4 hour cache timeout where the user will have to wait an extra 15s for results. I'm okay with this edge case.
-        $cached = Cache::store('redis')->get($cacheKey);
-        while(Cache::store('redis')->has($lockKey)) {
-            $cached = Cache::store('redis')->get($cacheKey);
-            if ($cached) {
-                break;
-            }
-            sleep(1);
-        }
-        Cache::store('redis')->put($lockKey, '1', 12);
-        if(config('railcontent.recsys.use_caching') && !empty($cached) && array_filter($cached)) {
-            $recommendations = $cached;
-            Log::info('Retrieving recommendations from Cache for Key ' . $cacheKey .' :' . $user_id . '-' . $brand . '-' . $sectionString);
+        $identifier = implode('-', [$userId, $brand, $sectionString]);
+        $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($identifier);
+        $lockKey = 'RECSYS-LOCK-'.CacheHelper::getKeyFromArguments($identifier);
+        if ($useCaching) {
+            Cache::lock($lockKey, 15)->block(15, function () use ($userId, $brand, $sections, $useFastImplementation, $cacheKey, $identifier, & $recommendations) {
+                $cached = Cache::store('redis')->get($cacheKey);
+                if (!empty($cached) && array_filter($cached)) {
+                    $recommendations = $cached;
+                    Log::info('Pull recommendations from Cache for Key ' . $cacheKey . ' :' . $identifier);
+                } else {
+                    $recommendations = $this->pullRecommendations(
+                        $userId,
+                        $brand,
+                        $sections,
+                        $useFastImplementation,
+                        $cacheKey,
+                        $identifier
+                    );
+                }
+            });
         } else {
-            Log::info('Retrieving recommendations from Huggingface for Key ' . $cacheKey .' :' . $user_id . '-' . $brand . '-' . $sectionString);
-            $recommendations = $this->recommendationService->getFilteredRecommendations($user_id, $brand, $sections, $useFastImplementation);
-
-            Cache::store('redis')
-                ->put($cacheKey, $recommendations, $ttl);
+            $recommendations = $this->pullRecommendations($userId, $brand, $sections, $useFastImplementation);
         }
+
         $filteredBySectionRecommendations = $this->filterRecommendedSections($recommendations, $sections);
-        $processedRecommendations = $this->postProcessRecommendations($filteredBySectionRecommendations, $pageSize, $page, $user_id, $groupByForLessonsPage);
+        $processedRecommendations = $this->postProcessRecommendations(
+            $filteredBySectionRecommendations,
+            $pageSize,
+            $page,
+            $userId,
+            $groupByForLessonsPage
+        );
         return $this->getContentFilterResultsFromRecommendations($processedRecommendations, $groupByForLessonsPage);
+    }
+
+    /**
+     * @param $userId
+     * @param $brand
+     * @param $sections
+     * @param $useFastImplementation -
+     * @param $cacheKey -
+     * @param $identifier -
+     * @return array|array[]
+     */
+    private function pullRecommendations($userId, $brand, $sections, $useFastImplementation, $cacheKey=null, $identifier=null)
+    {
+        $recommendations = $this->recommendationService->getFilteredRecommendations(
+            $userId,
+            $brand,
+            $sections,
+            $useFastImplementation
+        );
+        if ($cacheKey) {
+            Log::info('Pull recommendations from Huggingface for Key ' . $cacheKey . ' :' . $identifier);
+            $ttl = 60 * 60 * 4;
+            Cache::store('redis')->put($cacheKey, $recommendations, $ttl);
+        }
+        return $recommendations;
     }
 
     private function filterRecommendedSections($allContent, $sections)
@@ -185,7 +207,7 @@ class ContentService
         return $content;
     }
 
-    private function postProcessRecommendations($recommendations, $pageSize, $page, $user_id, array $groupByForLessonsPage = [])
+    private function postProcessRecommendations($recommendations, $pageSize, $page, $userId, array $groupByForLessonsPage = [])
     {
         if (!$recommendations) {
             return [
@@ -196,7 +218,7 @@ class ContentService
         }
         $removeSeen = config('railcontent.recsys.remove_seen_content');
         if ($removeSeen) {
-            $recommendations = $this->removePreviousSeenRecommendations($recommendations, $user_id);
+            $recommendations = $this->removePreviousSeenRecommendations($recommendations, $userId);
         }
         if ($groupByForLessonsPage) {
             $groupedByRecommendations = [];
@@ -248,10 +270,10 @@ class ContentService
         }
     }
 
-    private function removePreviousSeenRecommendations($recommendations, $user_id)
+    private function removePreviousSeenRecommendations($recommendations, $userId)
     {
         $allkey = zipperMerge($recommendations);
-        $previouslySeenContent = ContentUserProgress::where(['user_id' => $user_id])->whereIn('content_id', $allkey)->get()->pluck('content_id');
+        $previouslySeenContent = ContentUserProgress::where(['user_id' => $userId])->whereIn('content_id', $allkey)->get()->pluck('content_id');
         if ($previouslySeenContent->count() == 0) {
             return $recommendations;
         }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -135,15 +135,33 @@ class ContentService
                 return $section->value;
             }, $sections)
         );
+        $ttl = 60 * 60 * 4;
         $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($user_id, $brand, $sectionString);
+        $lockKey = 'RECSYS-LOCK' . CacheHelper::getKeyFromArguments($user_id, $brand, $sectionString);
+        // Logic here requires some explaination. Recommendation system calls each cost real $, so reducing extraneous calls is worth some messy logic.
+        // We cache recommendations contentids based on user,brand, and section. The external request can take up ta 10 seconds to return results.
+        // Concurrent (or close to concurrent) requests (such as during autoscrolling, will then call to the external service multiple times
+        // So we have a 2nd cache value (the lock) that indications an existing process has already started to retrieve results.
+        // If the original process returns (and fills the cache), we leave exit this loop.
+        // Otherwise we wait for the lock timeout of 15s, this shouldn't happen outside of exceptions in the pipeline,
+        // This will still be faster than making an external request.
+        // there is a small window at the end of the 4 hour cache timeout where the user will have to wait an extra 15s for results. I'm okay with this edge case.
         $cached = Cache::store('redis')->get($cacheKey);
+        while(Cache::store('redis')->has($lockKey)) {
+            $cached = Cache::store('redis')->get($cacheKey);
+            if ($cached) {
+                break;
+            }
+            sleep(1);
+        }
+        Cache::store('redis')->put($lockKey, '1', 12);
         if(config('railcontent.recsys.use_caching') && !empty($cached) && array_filter($cached)) {
             $recommendations = $cached;
             Log::info('Retrieving recommendations from Cache for Key ' . $cacheKey .' :' . $user_id . '-' . $brand . '-' . $sectionString);
         } else {
             Log::info('Retrieving recommendations from Huggingface for Key ' . $cacheKey .' :' . $user_id . '-' . $brand . '-' . $sectionString);
             $recommendations = $this->recommendationService->getFilteredRecommendations($user_id, $brand, $sections, $useFastImplementation);
-            $ttl = 60 * 60 * 4;
+
             Cache::store('redis')
                 ->put($cacheKey, $recommendations, $ttl);
         }

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -123,22 +123,22 @@ class ContentService
     {
         $useFastImplementation = config('railcontent.recsys.use_fast_implementation');
         $useCaching = config('railcontent.recsys.use_caching');
-
-        $sectionString = !$useFastImplementation || count($sections) == 0 ? 'ALL' : implode(
-            '-',
-            array_map(function ($section) {
-                return $section->value;
-            }, $sections)
-        );
-        $identifier = implode('-', [$userId, $brand, $sectionString]);
-        $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($identifier);
-        $lockKey = 'RECSYS-LOCK-'.CacheHelper::getKeyFromArguments($identifier);
+        
         if ($useCaching) {
+            $sectionString = !$useFastImplementation || count($sections) == 0 ? 'ALL' : implode(
+                '-',
+                array_map(function ($section) {
+                    return $section->value;
+                }, $sections)
+            );
+            $identifier = implode('-', [$userId, $brand, $sectionString]);
+            $cacheKey = 'RECSYS-' . CacheHelper::getKeyFromArguments($identifier);
+            $lockKey = 'RECSYS-LOCK-'.CacheHelper::getKeyFromArguments($identifier);
             Cache::lock($lockKey, 15)->block(15, function () use ($userId, $brand, $sections, $useFastImplementation, $cacheKey, $identifier, & $recommendations) {
                 $cached = Cache::store('redis')->get($cacheKey);
                 if (!empty($cached) && array_filter($cached)) {
                     $recommendations = $cached;
-                    Log::info('Pull recommendations from Cache for Key ' . $cacheKey . ' :' . $identifier);
+                    Log::info('Retrieve recommendations from Cache for Key ' . $cacheKey . ' :' . $identifier);
                 } else {
                     $recommendations = $this->pullRecommendations(
                         $userId,
@@ -183,7 +183,7 @@ class ContentService
             $useFastImplementation
         );
         if ($cacheKey) {
-            Log::info('Pull recommendations from Huggingface for Key ' . $cacheKey . ' :' . $identifier);
+            Log::info('Retrieve recommendations from Huggingface for Key ' . $cacheKey . ' :' . $identifier);
             $ttl = 60 * 60 * 4;
             Cache::store('redis')->put($cacheKey, $recommendations, $ttl);
         }


### PR DESCRIPTION
See comments in code.

Testing:
The debugger is honestly the best place to test this.
1. Put a breakpoint at line 142 and 144
2. open two tabs and put https://dev.musora.com:8443/pianote/lessons/recommended into the url but don't start
3. open one
4. you'll need to go quickly for the next section (or edit the timeout value of the lock to >15s)
5. once the debugger is past the first gate (line 151), start the 2nd tab.
6. The 2nd tab should loop in the while() loop 
7. continue the 1st tab debugger to return the values and populate the cache
8. the 2nd tab should exit the loop when the cached values from above are populated
whew.