### PR TITLE
If the user search by empty string we receive null in the BE

### DIFF
--- a/src/Helpers/FiltersHelper.php
+++ b/src/Helpers/FiltersHelper.php
@@ -142,7 +142,7 @@ class FiltersHelper
         }
 
         // Process 'title' filter
-        if ($request->has('title') && $request->get('title') !== null) {
+        if ($request->filled('title')) {
             self::processTitleFilter($request->get('title'));
         }
     }

--- a/src/Helpers/FiltersHelper.php
+++ b/src/Helpers/FiltersHelper.php
@@ -142,7 +142,7 @@ class FiltersHelper
         }
 
         // Process 'title' filter
-        if ($request->has('title')) {
+        if ($request->has('title') && $request->get('title') !== null) {
             self::processTitleFilter($request->get('title'));
         }
     }


### PR DESCRIPTION
[BE-187](https://musora.atlassian.net/jira/software/c/projects/BE/boards/41?assignee=712020%3A61fc08e8-0039-472f-8851-3a58c29af95d&selectedIssue=BE-187)
 
- Railcontent FiltersHelper processTitleFilter null error
- If the user search by empty string we receive null in the BE