### PR TITLE
Fix RecSys Pagination for content the user doesn't have access to

### DIFF
--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -246,7 +246,9 @@ class ContentService
                 $zippered = zipperMerge($toZipper);
                 $numGroups += 1;
                 $totalCount += count($zippered);
+                $zippered = $this->contentRepository->getByIds($zippered);
                 $zippered = $this->paginateRecommendations($zippered, $pageSize, $page);
+                $zippered = Decorator::decorate($zippered, 'group');
                 $groupedByRecommendations[] = [
                     'grouped_by_field' => $index,
                     'lessons_grouped_by_field' => implode(',', $zippered), // exploded values,
@@ -274,6 +276,7 @@ class ContentService
         } else {
             $recommendations = zipperMerge($recommendations);
             $totalCount = count($recommendations);
+            $recommendations = $this->contentRepository->getByIds($recommendations);
             $recommendations = $this->paginateRecommendations($recommendations, $pageSize, $page);
             return [
                 'recommendations' => $recommendations,
@@ -302,21 +305,12 @@ class ContentService
 
     private function getContentFilterResultsFromRecommendations($recommendations, $isGroupedBy)
     {
-        if ($isGroupedBy) {
-            foreach($recommendations['recommendations'] as $index => $groupedBy) {
-                $recommendations['recommendations'][$index]['lessons'] = $this->getByIds($groupedBy['lessons']);
-            }
-            $content = $recommendations['recommendations'];
-            $content = Decorator::decorate($content, 'group');
-        } else {
-            $content = $this->getByIds($recommendations['recommendations']);
-        }
         $filterOptions = [
             "type" => ["Recommendation"],
         ];
 
         return (new ContentFilterResultsEntity([
-            'results' => $content,
+            'results' => $recommendations['recommendations'],
             'filter_options' => $filterOptions,
             'total_results' => $recommendations['totalCount'],
             'total_lessons' => $recommendations['totalLessons'] //TODO this needs to be updated for groupBy

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -248,10 +248,11 @@ class ContentService
                 $totalCount += count($zippered);
                 $zippered = $this->contentRepository->getByIds($zippered);
                 $zippered = $this->paginateRecommendations($zippered, $pageSize, $page);
+                $servedIds = $zippered->pluck('id')->toArray();
                 $zippered = Decorator::decorate($zippered, 'group');
                 $groupedByRecommendations[] = [
                     'grouped_by_field' => $index,
-                    'lessons_grouped_by_field' => implode(',', $zippered), // exploded values,
+                    'lessons_grouped_by_field' => implode(',', $servedIds),
                     'type' => 'recommended',
                     'recommended' => $index,
                     'id' => $index,

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -243,13 +243,13 @@ class ContentService
                 foreach($groupBySections as $section) {
                     $toZipper[] = $recommendations[$section->value] ?? [];
                 }
-                $zippered = zipperMerge($toZipper);
+                $processedRecommendations = zipperMerge($toZipper);
                 $numGroups += 1;
-                $totalCount += count($zippered);
-                $zippered = $this->contentRepository->getByIds($zippered);
-                $zippered = $this->paginateRecommendations($zippered, $pageSize, $page);
-                $servedIds = $zippered->pluck('id')->toArray();
-                $zippered = Decorator::decorate($zippered, 'group');
+                $totalCount += count($processedRecommendations);
+                $processedRecommendations = $this->contentRepository->getByIds($processedRecommendations);
+                $processedRecommendations = $this->paginateRecommendations($processedRecommendations, $pageSize, $page);
+                $servedIds = $processedRecommendations->pluck('id')->toArray();
+                $processedRecommendations = Decorator::decorate($processedRecommendations, 'group');
                 $groupedByRecommendations[] = [
                     'grouped_by_field' => $index,
                     'lessons_grouped_by_field' => implode(',', $servedIds),
@@ -265,7 +265,7 @@ class ContentService
                         'position' => 1,
                     ]],
                     'all_lessons_count' => $totalCount,
-                    'lessons' => $zippered,
+                    'lessons' => $processedRecommendations,
                     'data' => []
                 ];
             }
@@ -275,12 +275,12 @@ class ContentService
                 'totalLessons' => $totalCount //TODO fix this to count the minimum of each
             ];
         } else {
-            $recommendations = zipperMerge($recommendations);
-            $totalCount = count($recommendations);
-            $recommendations = $this->contentRepository->getByIds($recommendations);
-            $recommendations = $this->paginateRecommendations($recommendations, $pageSize, $page);
+            $processedRecommendations = zipperMerge($recommendations);
+            $totalCount = count($processedRecommendations);
+            $processedRecommendations = $this->contentRepository->getByIds($processedRecommendations);
+            $processedRecommendations = $this->paginateRecommendations($processedRecommendations, $pageSize, $page);
             return [
-                'recommendations' => $recommendations,
+                'recommendations' => $processedRecommendations,
                 'totalCount' => $totalCount,
                 'totalLessons' => $totalCount
             ];

--- a/src/Services/RecommendationService.php
+++ b/src/Services/RecommendationService.php
@@ -117,10 +117,10 @@ class RecommendationService
         return $recommendations;
     }
 
-    private function getUserRecommendationsOrColdStartFromDB(int $userID, string $brand, string $section, int $limit = 20)
+    private function getUserRecommendationsOrColdStartFromDB(int $userID, string $brand, string $section)
     {
         $tableName = $this->getTableName($brand, $section);
-        $recommendations = DB::table($tableName)->select('content_id')->where('user_id', $userID)->orderBy('recommendation_rank')->limit($limit)->get()->pluck('content_id');
+        $recommendations = DB::table($tableName)->select('content_id')->where('user_id', $userID)->orderBy('recommendation_rank')->get()->pluck('content_id');
         if ($recommendations->isEmpty()) {
             $user = $this->userService->getByIdOrNull($userID);
             if ($user && ($user->isAPlusMember() || ($user->isABasicMember() || $section != RecommenderSection::Song->value))) {


### PR DESCRIPTION
Now we handle pagination after retrieving data from the DB. This means that situations where there are permissions changes (or a dev is using staging dbs) the pagination will return the correct number of results instead of variable length packages.