### PR TITLE
Include state from the event for UserContentProgressEventListener

### DIFF
--- a/src/Listeners/UserContentProgressEventListener.php
+++ b/src/Listeners/UserContentProgressEventListener.php
@@ -151,6 +151,7 @@ class UserContentProgressEventListener extends Event
                 'content_id' => $event->contentId,
                 'user_id' => $event->userId,
             ], [
+                'state' => $event->progressStatus,
                 'higher_key_progress' => $higherKeyProgress,
                 'updated_on' => Carbon::now()
                     ->toDateTimeString(),


### PR DESCRIPTION
[TP-730](https://musora.atlassian.net/browse/TP-730)

My local wasn't working to get into a challenge, so I tested this out on the devendpoint:

```php
public function handleRequest(Request $request, $arg1 = null)
    {
        $userId = user()->id;
        $contentId = 276693;
      
        $event = new UserContentProgressSaved($userId, $contentId, 0, ProgressState::Started);
        $listener = app(UserContentProgressEventListener::class);
        $listener->handle($event);
      
        return view("pages.devendpoint", ['results' => 'some results here', 'json_results' => ['key1' => 'value1']]);
    }
```

Hitting it before the fix would throw the error, and after would successfully store the entry