### PR TITLE
fix(MU2-185): Filter out song recommendations from basic users

### DIFF
--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -141,19 +141,7 @@ class ContentService
         } else {
             $groupBySections = [];
         }
-        if(!$user->hasSongsAccess($brand)) {
-            $groupBySections =
-                array_filter($groupBySections, function ($key) {
-                    return $key != 'Songs You Might Like';
-                },
-                    ARRAY_FILTER_USE_KEY);
 
-            $sections = array_values(
-                array_filter($sections, function ($section) {
-                    return $section->name != 'Song';
-                })
-            );
-        }
         $useFastImplementation = config('railcontent.recsys.use_fast_implementation');
         $useCaching = config('railcontent.recsys.use_caching');
 
@@ -200,6 +188,14 @@ class ContentService
             }
         } else {
             $recommendations = $this->pullRecommendations($userId, $brand, $sections, $useFastImplementation);
+        }
+
+        if (!$user->hasSongsAccess($brand)) {
+            $recommendations = array_filter(
+                $recommendations,
+                fn ($key) => $key != RecommenderSection::Song->name,
+                ARRAY_FILTER_USE_KEY
+            );
         }
 
         $filteredBySectionRecommendations = $this->filterRecommendedSections($recommendations, $sections);

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -193,7 +193,7 @@ class ContentService
         if (!$user->hasSongsAccess($brand)) {
             $recommendations = array_filter(
                 $recommendations,
-                fn ($key) => $key != RecommenderSection::Song->name,
+                fn ($key) => $key != RecommenderSection::Song->value,
                 ARRAY_FILTER_USE_KEY
             );
         }


### PR DESCRIPTION
The previous check was cleaning up the sections when it only contained songs, making the service to return all recommended sections (including songs). This was allowing basic users to see content that should be hidden from them.

New check leave the sections as is, so it can fetch only the content types needed and then filter songs out later for basic users.