### PR TITLE
fix(BR-157): Filter out need_access content on service level

### DIFF
--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -333,7 +333,7 @@ class ContentService
         return $filteredContent;
     }
 
-    private function removeNeedsAccessRecommendations($recommendations)
+    private function removeNeedsAccessRecommendations(array $recommendations) : array
     {
         $allIds = zipperMerge($recommendations);
         $documents = $this->sanityGateway->getByRailContentIds($allIds);

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -263,7 +263,7 @@ class ContentService
             $recommendations = $this->removePreviousSeenRecommendations($recommendations, $userId);
         }
 
-        $recommendations = $this->removeNeedsAccessRecommendations($recommendations);
+        $recommendations = $this->removeNeedsAccessRecommendationsAndGetDocuments($recommendations);
 
         if ($groupByForLessonsPage) {
             $groupedByRecommendations = [];
@@ -279,9 +279,13 @@ class ContentService
                 $numGroups += 1;
                 $totalCount += count($zippered);
                 $zippered = $this->paginateRecommendations($zippered, $pageSize, $page);
+                $zipperedRailcontentIds = [];
+                foreach ($zippered as $recommendation) {
+                    $zipperedRailcontentIds[] = $recommendation["railcontent_id"];
+                }
                 $groupedByRecommendations[] = [
                     'grouped_by_field' => $index,
-                    'lessons_grouped_by_field' => implode(',', $zippered), // exploded values,
+                    'lessons_grouped_by_field' => implode(',', $zipperedRailcontentIds), // exploded values,
                     'type' => 'recommended',
                     'recommended' => $index,
                     'id' => $index,
@@ -332,7 +336,12 @@ class ContentService
         return $filteredContent;
     }
 
-    private function removeNeedsAccessRecommendations(array $recommendations) : array
+    /**
+     * intakes an array of railcontent_id's, and returns an array of full content documents (arrays)
+     * @param array $recommendations
+     * @return array
+     */
+    private function removeNeedsAccessRecommendationsAndGetDocuments(array $recommendations) : array
     {
         $allIds = zipperMerge($recommendations);
         $documents = $this->sanityGateway->getByRailContentIds($allIds);
@@ -341,10 +350,9 @@ class ContentService
             $document = array_values(array_filter($documents, function ($doc) use ($section) {
                 return in_array($doc['id'], $section);
             }));
-            //check if document doesnt need access
             foreach ($document as $doc) {
                 if ($doc['need_access'] === false) {
-                    $filteredContent[$sectionName][] = $doc['railcontent_id'];
+                    $filteredContent[$sectionName][] = $doc;
                 }
             }
         }
@@ -354,13 +362,10 @@ class ContentService
     private function getContentFilterResultsFromRecommendations($recommendations, $isGroupedBy)
     {
         if ($isGroupedBy) {
-            foreach($recommendations['recommendations'] as $index => $groupedBy) {
-                $recommendations['recommendations'][$index]['lessons'] = $this->sanityGateway->getByRailContentIds($groupedBy['lessons']);
-            }
             $content = $recommendations['recommendations'];
             $content = Decorator::decorate($content, 'group');
         } else {
-            $content = $this->sanityGateway->getByRailContentIds($recommendations['recommendations']);
+            $content = $recommendations['recommendations'];
         }
         $filterOptions = [
             "type" => ["Recommendation"],

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -263,7 +263,6 @@ class ContentService
             $recommendations = $this->removePreviousSeenRecommendations($recommendations, $userId);
         }
 
-        //remove content that doesnt match permissions
         $recommendations = $this->removeNeedsAccessRecommendations($recommendations);
 
         if ($groupByForLessonsPage) {

--- a/src/Services/ContentService.php
+++ b/src/Services/ContentService.php
@@ -262,6 +262,10 @@ class ContentService
         if ($removeSeen) {
             $recommendations = $this->removePreviousSeenRecommendations($recommendations, $userId);
         }
+
+        //remove content that doesnt match permissions
+        $recommendations = $this->removeNeedsAccessRecommendations($recommendations);
+
         if ($groupByForLessonsPage) {
             $groupedByRecommendations = [];
             $totalCount = 0;
@@ -325,6 +329,25 @@ class ContentService
             $previouslySeenContent->contains(fn($value, $key) =>
                 $contentID != $value
             )));
+        }
+        return $filteredContent;
+    }
+
+    private function removeNeedsAccessRecommendations($recommendations)
+    {
+        $allIds = zipperMerge($recommendations);
+        $documents = $this->sanityGateway->getByRailContentIds($allIds);
+        $filteredContent = [];
+        foreach ($recommendations as $sectionName => $section) {
+            $document = array_values(array_filter($documents, function ($doc) use ($section) {
+                return in_array($doc['id'], $section);
+            }));
+            //check if document doesnt need access
+            foreach ($document as $doc) {
+                if ($doc['need_access'] === false) {
+                    $filteredContent[$sectionName][] = $doc['railcontent_id'];
+                }
+            }
         }
         return $filteredContent;
     }


### PR DESCRIPTION
[BR-157](https://musora.atlassian.net/browse/BR-157)

Main issue:
* cold start recsys table had content that most users dont have access to
* the logic to retrieve cold-start table info does not check for access, and so bypassed any needs-access check

Changes:
* implemented a service-level check in `postProcessRecommendations` for all recommended content to be showed as a card
* uses need_access flag to determine

Testing:
* obtain a new piano user, admin status is nice for later (https://dev.musora.com:8443/musora-center#/users/796696)
  * ensure it does not have Singing Starter Kit permission
test admin account
* login to https://dev.musora.com:8443/singeo homepage
* activate admin switch, so we can see all content
* there should be Singing Starter Kit, which is a course pack with only its bespoke permission (so most students cant see it)
test student view
* flip off the admin switch, to see a student perspective
* there should be no Singing Starter Kit
test bespoke permission
* in MC (https://dev.musora.com:8443/musora-center#/users/796696), add Singing Starter Kit permission
* go back to homepage as a student view, and you should once again see SSK!
* thanks for coming to my ted talk