### PR TITLE
fix - recsys v3 - fix module source

### DIFF
--- a/src/Services/RecommendationService.php
+++ b/src/Services/RecommendationService.php
@@ -170,15 +170,16 @@ class RecommendationService
         if ($this->defaultAccessMethod != AccessMethod::DB) {
             return [];
         }
-        $type = str_replace('-', '_', $content->type);
-        if (is_null(RecommenderSection::tryFrom(strtoupper($type)))) {
-            return [];
-        }
+        $section = match($content->type) {
+            'song' => RecommenderSection::Song->value,
+            'workout' => RecommenderSection::Workout->value,
+            default => RecommenderSection::Lesson->value,
+        };
         $brand = $content->brand;
         $moduleSource = [];
 
-        $table = $this->getTableName($brand, $type);
-        $beginnerTable = $this->getTableName($brand, $type, true);
+        $table = $this->getTableName($brand, $section);
+        $beginnerTable = $this->getTableName($brand, $section, true);
 
         $recommendation =
             DB::table($table)


### PR DESCRIPTION
Details:
- previous we had a 1:1 on section and content->type, now we have a number of content types in the lesson .
- The patch using a match song and workout and everything else searches the lesson table.
Tested with mwp DevEndpoint by pulling in the updated method directly into the vendor folder and calling:  
`return $this->recommendationService->getModuleSourceFromContent(4, Content::find(359002));`
user_id: 4
content_id: 405308 (workout), 316726 (lesson table), 316726 (song), 
beginner items song 264509